### PR TITLE
 	get_cached_avatar_image no longer in use 

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -813,7 +813,7 @@ if(! class_exists('App')) {
 			return $this->curl_headers;
 		}
 
-//FIXME or remove
+		/* //MicMee 20120109 function no longer in use commented out
 		function get_cached_avatar_image($avatar_image){
 			if($this->cached_profile_image[$avatar_image])
 				return $this->cached_profile_image[$avatar_image];
@@ -835,6 +835,7 @@ if(! class_exists('App')) {
 			}
 			return $this->cached_profile_image[$avatar_image];
 		}
+		*/
 
 		function get_template_engine() {
 			return $this->theme['template_engine'];


### PR DESCRIPTION
commented out function  get_cached_avatar_image in boot.php,
Found no place where this function is called from, so I commented the function out.
My first change, please check and gimme some feedback. 
