### PR TITLE
only show categories this channel has used

### DIFF
--- a/include/contact_widgets.php
+++ b/include/contact_widgets.php
@@ -85,7 +85,7 @@ function categories_widget($baseurl,$selected = '') {
                 order by term.term asc",
 		intval($a->profile['profile_uid']),
 	        intval(TERM_CATEGORY),
-                $a->profile['channel_hash']
+	        dbesc($a->profile['channel_hash'])
 	);
 	if($r && count($r)) {
 		foreach($r as $rr)


### PR DESCRIPTION
I don't know if others will agree, but I think it is better that the categories widget only shows categories that have been used in posts by the channel we are viewing, and does not include categories only their contacts have used.  Unfortunately this means joining term to item.  I'm open to ideas if others don't like this, or think it should be accomplished in some other way.
