### PR TITLE
add option to hide login form from homepage

### DIFF
--- a/mod/admin.php
+++ b/mod/admin.php
@@ -234,6 +234,7 @@ function admin_page_site_post(&$a){
 	$allowed_email		=	((x($_POST,'allowed_email'))	? notags(trim($_POST['allowed_email']))		: '');
 	$block_public		=	((x($_POST,'block_public'))		? True	:	False);
 	$force_publish		=	((x($_POST,'publish_all'))		? True	:	False);
+	$no_login_on_homepage	=	((x($_POST,'no_login_on_homepage'))		? True	:	False);
 	$global_directory	=	((x($_POST,'directory_submit_url'))	? notags(trim($_POST['directory_submit_url']))	: '');
 	$no_community_page	=	!((x($_POST,'no_community_page'))	? True	:	False);
 
@@ -291,6 +292,7 @@ function admin_page_site_post(&$a){
 	set_config('system','poll_interval',$poll_interval);
 	set_config('system','maxloadavg',$maxloadavg);
 	set_config('system','sitename',$sitename);
+	set_config('system','no_login_on_homepage',$no_login_on_homepage);
 
 	if ($banner=="") {
 		del_config('system','banner');
@@ -440,6 +442,7 @@ function admin_page_site(&$a) {
 		'$allowed_email'	=> array('allowed_email', t("Allowed email domains"), get_config('system','allowed_email'), t("Comma separated list of domains which are allowed in email addresses for registrations to this site. Wildcards are accepted. Empty to allow any domains")),
 		'$block_public'		=> array('block_public', t("Block public"), get_config('system','block_public'), t("Check to block public access to all otherwise public personal pages on this site unless you are currently logged in.")),
 		'$force_publish'	=> array('publish_all', t("Force publish"), get_config('system','publish_all'), t("Check to force all profiles on this site to be listed in the site directory.")),
+		'$no_login_on_homepage'	=> array('no_login_on_homepage', t("No login on Homepage"), get_config('system','no_login_on_homepage'), t("Check to hide the login form from your sites homepage when visitors arrive who are not logged in (e.g. when you put the content of the homepage in via the site channel).")),
 			
 		'$proxyuser'		=> array('proxyuser', t("Proxy user"), get_config('system','proxyuser'), ""),
 		'$proxy'			=> array('proxy', t("Proxy URL"), get_config('system','proxy'), ""),

--- a/mod/home.php
+++ b/mod/home.php
@@ -78,6 +78,7 @@ require_once('include/conversation.php');
  		$o .= file_get_contents('home.html');
 }
 
+	if (!$a->config['system']['no_login_on_homepage'])
 		$o .= login(($a->config['system']['register_policy'] == REGISTER_CLOSED) ? 0 : 1);
 	
 	call_hooks("home_content",$o);

--- a/view/tpl/admin_site.tpl
+++ b/view/tpl/admin_site.tpl
@@ -47,6 +47,7 @@
     {{include file="field_select.tpl" field=$theme_mobile}}
     {{include file="field_select.tpl" field=$theme_accessibility}}
     {{include file="field_input.tpl" field=$site_channel}}
+    {{include file="field_checkbox.tpl" field=$no_login_on_homepage}}
 
 	
 	<div class="submit"><input type="submit" name="page_site" value="{{$submit}}" /></div>


### PR DESCRIPTION
On my node I use the site channel to generate the homepage and have the login only linked from the menu. With this option node admins can simply choose to not show the login form on the home screen.
