### PR TITLE
link hover colour remains user set link_colour (w/o change default,Mike)

### DIFF
--- a/view/theme/redbasic/css/style.css
+++ b/view/theme/redbasic/css/style.css
@@ -44,7 +44,7 @@ a, a:visited, a:link, .fakelink, .fakelink:visited, .fakelink:link {
 	text-decoration: none; 
 }
 
-a:hover, .fakelink:hover { color: #44AAFF; text-decoration: underline; }
+a:hover, .fakelink:hover { color: $link_colour; text-decoration: underline; }
 
 .fakelink {
 	cursor: pointer;


### PR DESCRIPTION
Sets the link hover to the same as $link_colour (only indication is the underline), for consistency,
and without changing the blue default this time.
