### PR TITLE
reimplementing navbar colours that were undone by git-marjus

### DIFF
--- a/view/theme/redbasic/css/style.css
+++ b/view/theme/redbasic/css/style.css
@@ -140,8 +140,6 @@ blockquote {
 	filter:alpha(opacity=100);
 }
 
-/* this is not yet supported
-
 nav {
 	background-image: linear-gradient(bottom, $nav_bg_1 26%, $nav_bg_2 82%);
 	background-image: -o-linear-gradient(bottom, $nav_bg_1 26%, $nav_bg_2 82%);
@@ -163,7 +161,6 @@ nav:hover {
 	filter:alpha(opacity=100);
 
 }
-*/
 
 nav #site-location {
 	color: #888a85;

--- a/view/theme/redbasic/tpl/theme_settings.tpl
+++ b/view/theme/redbasic/tpl/theme_settings.tpl
@@ -4,7 +4,7 @@
 </div>
 
 {{if $expert}}
-{{* include file="field_select.tpl" field=$nav_colour *}}
+{{include file="field_select.tpl" field=$nav_colour}}
 {{include file="field_input.tpl" field=$banner_colour}}
 {{include file="field_input.tpl" field=$link_colour}}
 {{include file="field_input.tpl" field=$bgcolour}}


### PR DESCRIPTION
someone (git-arjus) commented out the changes I made a couple weeks ago to allow manipulation of navbar colours.
There's still something else done impeding this change, but with this push, at least the colour shows on hover. Still trying to figure out what all else needs done to fix it.
