### PR TITLE
A CSS cheat to make the item-tools usable again

### DIFF
--- a/view/theme/redbasic/css/style.css
+++ b/view/theme/redbasic/css/style.css
@@ -1920,7 +1920,7 @@ img.mail-list-sender-photo {
 }
 
 .wall-item-content-wrapper:hover{
-	z-index:100000;
+	z-index:99;
 }
 
 .wall-item-comment-wrapper {


### PR DESCRIPTION
when opacity is set.
