### PR TITLE
Language selection: case-insensitive and system language

### DIFF
--- a/include/language.php
+++ b/include/language.php
@@ -43,8 +43,6 @@ function get_browser_language() {
 			arsort($langs, SORT_NUMERIC);
 		}
 	}
-	else
-		$langs['en'] = 1;
 
 	return $langs;
 }
@@ -65,6 +63,7 @@ function get_best_language() {
 
 	if(isset($langs) && count($langs)) {
 		foreach ($langs as $lang => $v) {
+			$lang = strtolower($lang);
 			if(file_exists("view/$lang") && is_dir("view/$lang")) {
 				$preferred = $lang;
 				break;

--- a/index.php
+++ b/index.php
@@ -27,9 +27,6 @@ $a->install = ((file_exists('.htconfig.php') && filesize('.htconfig.php')) ? fal
 
 @include(".htconfig.php");
 
-$a->language = get_best_language();
-	
-
 /**
  *
  * Try to open the database;
@@ -54,6 +51,7 @@ if(! $a->install) {
 	load_hooks();
 	call_hooks('init_1');
 	
+	$a->language = get_best_language();
 	load_translation_table($a->language);
 	// Force the cookie to be secure (https only) if this site is SSL enabled. Must be done before session_start().
 
@@ -69,6 +67,7 @@ if(! $a->install) {
 }
 else {
 	// load translations but do not check plugins as we have no database
+	$a->language = get_best_language();
 	load_translation_table($a->language,true);
 }
 


### PR DESCRIPTION
Fixed ignoring HTTP_ACCEPT_LANGUAGE tags that had uppercase
characters.
^ This shouldn't need any attention.

Fixed defining a->language too soon to ever get the system language.
^ Mike please see if I didn't screw anything up since I messed with index.php ;-) From what I could find none of the stuff I skipped uses language anyway, so it's fine only to define that at those later points.

Anyway I tested both changes and everything is working as expected.

Oh yeah, this should improve the situation, if not fix, issue #465 
