### PR TITLE
Implements a new permission level PERMS_PENDING

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -289,6 +289,7 @@ define ( 'PERMS_SITE'       , 0x0004 );
 define ( 'PERMS_CONTACTS'   , 0x0008 );
 define ( 'PERMS_SPECIFIC'   , 0x0080 );
 define ( 'PERMS_AUTHED'     , 0x0100 );
+define ( 'PERMS_PENDING'    , 0x0200 );
 
 
 // Address book flags

--- a/include/items.php
+++ b/include/items.php
@@ -943,6 +943,8 @@ function map_scope($scope) {
 			return 'network: red';
 		case PERMS_SITE:
 			return 'site: ' . get_app()->get_hostname();
+		case PERMS_PENDING:
+			return 'any connections';
 		case PERMS_CONTACTS:
 		default:
 			return 'contacts';
@@ -4085,7 +4087,7 @@ function items_fetch($arr,$channel = null,$observer_hash = null,$client_mode = C
     }
 
 	if(! array_key_exists('nouveau',$arr)) {
-	    $sql_extra2 = " AND item.parent = item.id ";
+		$sql_extra2 = " AND item.parent = item.id ";
 		$sql_extra3 = '';
 	}
 
@@ -4126,12 +4128,12 @@ function items_fetch($arr,$channel = null,$observer_hash = null,$client_mode = C
         $pager_sql = sprintf(" LIMIT %d, %d ",intval($arr['start']), intval($arr['records']));
 
 	if(array_key_exists('cmin',$arr) || array_key_exists('cmax',$arr)) {
-	    if(($arr['cmin'] != 0) || ($arr['cmax'] != 99)) {
+		if(($arr['cmin'] != 0) || ($arr['cmax'] != 99)) {
 
-    	    // Not everybody who shows up in the network stream will be in your address book.
-        	// By default those that aren't are assumed to have closeness = 99; but this isn't
-	        // recorded anywhere. So if cmax is 99, we'll open the search up to anybody in
-    	    // the stream with a NULL address book entry.
+			// Not everybody who shows up in the network stream will be in your address book.
+			// By default those that aren't are assumed to have closeness = 99; but this isn't
+			// recorded anywhere. So if cmax is 99, we'll open the search up to anybody in
+			// the stream with a NULL address book entry.
 
 			$sql_nets .= " AND ";
 

--- a/include/permissions.php
+++ b/include/permissions.php
@@ -177,32 +177,36 @@ function get_all_perms($uid,$observer_xchan,$internal_use = true) {
 			continue;
 		}	
 
-		// If PERMS_CONTACTS or PERMS_SPECIFIC, they need to be in your address book
-		// $x is a valid address book entry
+		// From here on we require that the observer be a connection and
+		// handle whether we're allowing any, approved or specific ones
 
 		if(! $x) {
 			$ret[$perm_name] = false;
 			continue;
 		}
-		
+
 		// They are in your address book, but haven't been approved
+
+		if($r[0][$channel_perm] & PERMS_PENDING) {
+			$ret[$perm_name] = true;
+			continue;
+		}
 
 		if($x[0]['abook_flags'] & ABOOK_FLAG_PENDING) {
 			$ret[$perm_name] = false;
 			continue;
 		}
 
-		if(($r) && ($r[0][$channel_perm] & PERMS_CONTACTS)) {
+		// They're a contact, so they have permission
 
-			// They're a contact, so they have permission
-
+		if($r[0][$channel_perm] & PERMS_CONTACTS) {
 			$ret[$perm_name] = true;
 			continue;
 		}
 
 		// Permission granted to certain channels. Let's see if the observer is one of them
 
-		if(($r) && ($r[0][$channel_perm] & PERMS_SPECIFIC)) {
+		if($r[0][$channel_perm] & PERMS_SPECIFIC) {
 			if(($x[0]['abook_my_perms'] & $global_perms[$perm_name][1])) {
 				$ret[$perm_name] = true;
 				continue;
@@ -216,7 +220,6 @@ function get_all_perms($uid,$observer_xchan,$internal_use = true) {
 
 	}
 
-
 	$arr = array(
 		'channel_id'    => $uid,
 		'observer_hash' => $observer_xchan,
@@ -228,7 +231,6 @@ function get_all_perms($uid,$observer_xchan,$internal_use = true) {
 
 
 function perm_is_allowed($uid,$observer_xchan,$permission) {
-
 
 	$arr = array(
 		'channel_id'    => $uid,
@@ -280,7 +282,6 @@ function perm_is_allowed($uid,$observer_xchan,$permission) {
 		}
 	}
 
-
 	// Check if this $uid is actually the $observer_xchan
 
 	if($r[0]['channel_hash'] === $observer_xchan)
@@ -312,15 +313,26 @@ function perm_is_allowed($uid,$observer_xchan,$permission) {
 		if($c)
 			return true;
 		return false;
-	}	
+	}
+
+	// From here on we require that the observer be a connection and
+	// handle whether we're allowing any, approved or specific ones
 
 	if(! $x) {
 		return false;
 	}
 
+	// They are in your address book, but haven't been approved
+
+	if($r[0][$channel_perm] & PERMS_PENDING) {
+		return true;
+	}
+
 	if($x[0]['abook_flags'] & ABOOK_FLAG_PENDING) {
 		return false;
 	}
+
+	// They're a contact, so they have permission
 
 	if($r[0][$channel_perm] & PERMS_CONTACTS) {
 		return true;
@@ -333,13 +345,9 @@ function perm_is_allowed($uid,$observer_xchan,$permission) {
 			return true;
 	}
 
-
-
-
 	// No permissions allowed.
 
 	return false;		
-
 }
 
 
@@ -354,7 +362,6 @@ function check_list_permissions($uid,$arr,$perm) {
 				$result[] = $x;
 	return($result);
 }
-
 
 
 function site_default_perms() {
@@ -377,7 +384,6 @@ function site_default_perms() {
 		'write_pages'   => 0,
 		'delegate'      => 0,
 	);
-
 
 	$global_perms = get_perms();
 	$ret = array();

--- a/include/security.php
+++ b/include/security.php
@@ -311,7 +311,7 @@ function check_form_security_token_redirectOnErr($err_redirect, $typename = '', 
 }
 function check_form_security_token_ForbiddenOnErr($typename = '', $formname = 'form_security_token') {
 	if (!check_form_security_token($typename, $formname)) {
-	    $a = get_app();
+		$a = get_app();
 		logger('check_form_security_token failed: user ' . $a->user['guid'] . ' - form element ' . $typename);
 		logger('check_form_security_token failed: _REQUEST data: ' . print_r($_REQUEST, true), LOGGER_DATA);
 		header('HTTP/1.1 403 Forbidden');
@@ -342,19 +342,22 @@ function init_groups_visitor($contact_id) {
 
 
 // This is used to determine which uid have posts which are visible to the logged in user (from the API) for the 
-// public_timeline, and we can use this in a community page by making $perms_min = PERMS_NETWORK unless logged in. 
+// public_timeline, and we can use this in a community page by making
+// $perms = (PERMS_NETWORK|PERMS_PUBLIC) unless logged in. 
 // Collect uids of everybody on this site who has opened their posts to everybody on this site (or greater visibility)
 // We always include yourself if logged in because you can always see your own posts
 // resolving granular permissions for the observer against every person and every post on the site
 // will likely be too expensive. 
 // Returns a string list of comma separated channel_ids suitable for direct inclusion in a SQL query
 
-function stream_perms_api_uids($perms_min = PERMS_SITE) {
+function stream_perms_api_uids($perms = NULL ) {
+	$perms = is_null($perms) ? (PERMS_SITE|PERMS_NETWORK|PERMS_PUBLIC) : $perms;
+
 	$ret = array();
 	if(local_user())
 		$ret[] = local_user();
-	$r = q("select channel_id from channel where channel_r_stream > 0 and channel_r_stream <= %d and not (channel_pageflags & %d)",
-		intval($perms_min),
+	$r = q("select channel_id from channel where channel_r_stream > 0 and (channel_r_stream & %d) and not (channel_pageflags & %d)",
+		intval($perms),
 		intval(PAGE_CENSORED|PAGE_SYSTEM|PAGE_REMOVED)
 	);
 	if($r)
@@ -373,13 +376,15 @@ function stream_perms_api_uids($perms_min = PERMS_SITE) {
 	return $str;
 }
 
-function stream_perms_xchans($perms_min = PERMS_SITE) {
+function stream_perms_xchans($perms = NULL ) {
+	$perms = is_null($perms) ? (PERMS_SITE|PERMS_NETWORK|PERMS_PUBLIC) : $perms;
+
 	$ret = array();
 	if(local_user())
 		$ret[] = get_observer_hash();
 
-	$r = q("select channel_hash from channel where channel_r_stream > 0 and channel_r_stream <= %d and not (channel_pageflags & %d)",
-		intval($perms_min),
+	$r = q("select channel_hash from channel where channel_r_stream > 0 and (channel_r_stream & %d) and not (channel_pageflags & %d)",
+		intval($perms),
 		intval(PAGE_CENSORED|PAGE_SYETEM|PAGE_REMOVED)
 	);
 	if($r)

--- a/mod/settings.php
+++ b/mod/settings.php
@@ -792,7 +792,8 @@ function settings_content(&$a) {
 		$perm_opts = array(
 			array( t('Nobody except yourself'), 0),
 			array( t('Only those you specifically allow'), PERMS_SPECIFIC), 
-			array( t('Anybody in your address book'), PERMS_CONTACTS),
+			array( t('Approved connections'), PERMS_CONTACTS),
+			array( t('Any connections'), PERMS_PENDING),
 			array( t('Anybody on this website'), PERMS_SITE),
 			array( t('Anybody in this network'), PERMS_NETWORK),
 			array( t('Anybody authenticated'), PERMS_AUTHED),

--- a/view/js/mod_settings.js
+++ b/view/js/mod_settings.js
@@ -25,100 +25,98 @@ $(document).ready(function() {
 });
 
 function channel_privacy_macro(n) {
-    if(n == 0) {
-        $('#id_view_stream option').eq(0).attr('selected','selected');
-        $('#id_view_profile option').eq(0).attr('selected','selected');
-        $('#id_view_photos option').eq(0).attr('selected','selected');
-        $('#id_view_contacts option').eq(0).attr('selected','selected');
-        $('#id_view_storage option').eq(0).attr('selected','selected');
-        $('#id_view_pages option').eq(0).attr('selected','selected');
-        $('#id_send_stream option').eq(0).attr('selected','selected');
-        $('#id_post_wall option').eq(0).attr('selected','selected');
-        $('#id_post_comments option').eq(0).attr('selected','selected');
-        $('#id_post_mail option').eq(0).attr('selected','selected');
-        $('#id_post_photos option').eq(0).attr('selected','selected');
-        $('#id_tag_deliver option').eq(0).attr('selected','selected');
-        $('#id_chat option').eq(0).attr('selected','selected');
-        $('#id_write_storage option').eq(0).attr('selected','selected');
-        $('#id_write_pages option').eq(0).attr('selected','selected');
-        $('#id_delegate option').eq(0).attr('selected','selected');
+	if(n == 0) {
+		$('#id_view_stream option').eq(0).attr('selected','selected');
+		$('#id_view_profile option').eq(0).attr('selected','selected');
+		$('#id_view_photos option').eq(0).attr('selected','selected');
+		$('#id_view_contacts option').eq(0).attr('selected','selected');
+		$('#id_view_storage option').eq(0).attr('selected','selected');
+		$('#id_view_pages option').eq(0).attr('selected','selected');
+		$('#id_send_stream option').eq(0).attr('selected','selected');
+		$('#id_post_wall option').eq(0).attr('selected','selected');
+		$('#id_post_comments option').eq(0).attr('selected','selected');
+		$('#id_post_mail option').eq(0).attr('selected','selected');
+		$('#id_post_photos option').eq(0).attr('selected','selected');
+		$('#id_tag_deliver option').eq(0).attr('selected','selected');
+		$('#id_chat option').eq(0).attr('selected','selected');
+		$('#id_write_storage option').eq(0).attr('selected','selected');
+		$('#id_write_pages option').eq(0).attr('selected','selected');
+		$('#id_delegate option').eq(0).attr('selected','selected');
 		$('#id_republish option').eq(0).attr('selected','selected');
 		$('#id_bookmark option').eq(0).attr('selected','selected');
 		$('#id_profile_in_directory_onoff .off').removeClass('hidden');
 		$('#id_profile_in_directory_onoff .on').addClass('hidden');
 		$('#id_profile_in_directory').val(0);
 	}
-    if(n == 1) {
-        $('#id_view_stream option').eq(1).attr('selected','selected');
-        $('#id_view_profile option').eq(1).attr('selected','selected');
-        $('#id_view_photos option').eq(1).attr('selected','selected');
-        $('#id_view_contacts option').eq(1).attr('selected','selected');
-        $('#id_view_storage option').eq(1).attr('selected','selected');
-        $('#id_view_pages option').eq(1).attr('selected','selected');
-        $('#id_send_stream option').eq(1).attr('selected','selected');
-        $('#id_post_wall option').eq(1).attr('selected','selected');
-        $('#id_post_comments option').eq(1).attr('selected','selected');
-        $('#id_post_mail option').eq(1).attr('selected','selected');
-        $('#id_post_photos option').eq(1).attr('selected','selected');
-        $('#id_tag_deliver option').eq(1).attr('selected','selected');
-        $('#id_chat option').eq(1).attr('selected','selected');
-        $('#id_write_storage option').eq(1).attr('selected','selected');
-        $('#id_write_pages option').eq(1).attr('selected','selected');
-        $('#id_delegate option').eq(0).attr('selected','selected');
+	if(n == 1) {
+		$('#id_view_stream option').eq(1).attr('selected','selected');
+		$('#id_view_profile option').eq(1).attr('selected','selected');
+		$('#id_view_photos option').eq(1).attr('selected','selected');
+		$('#id_view_contacts option').eq(1).attr('selected','selected');
+		$('#id_view_storage option').eq(1).attr('selected','selected');
+		$('#id_view_pages option').eq(1).attr('selected','selected');
+		$('#id_send_stream option').eq(1).attr('selected','selected');
+		$('#id_post_wall option').eq(1).attr('selected','selected');
+		$('#id_post_comments option').eq(1).attr('selected','selected');
+		$('#id_post_mail option').eq(1).attr('selected','selected');
+		$('#id_post_photos option').eq(1).attr('selected','selected');
+		$('#id_tag_deliver option').eq(1).attr('selected','selected');
+		$('#id_chat option').eq(1).attr('selected','selected');
+		$('#id_write_storage option').eq(1).attr('selected','selected');
+		$('#id_write_pages option').eq(1).attr('selected','selected');
+		$('#id_delegate option').eq(0).attr('selected','selected');
 		$('#id_republish option').eq(0).attr('selected','selected');
 		$('#id_bookmark option').eq(1).attr('selected','selected');
 		$('#id_profile_in_directory_onoff .off').removeClass('hidden');
 		$('#id_profile_in_directory_onoff .on').addClass('hidden');
 		$('#id_profile_in_directory').val(0);
 	}
-    if(n == 2) {
-        $('#id_view_stream option').eq(6).attr('selected','selected');
-        $('#id_view_profile option').eq(6).attr('selected','selected');
-        $('#id_view_photos option').eq(6).attr('selected','selected');
-        $('#id_view_contacts option').eq(6).attr('selected','selected');
-        $('#id_view_storage option').eq(6).attr('selected','selected');
-        $('#id_view_pages option').eq(6).attr('selected','selected');
-        $('#id_send_stream option').eq(2).attr('selected','selected');
-        $('#id_post_wall option').eq(1).attr('selected','selected');
-        $('#id_post_comments option').eq(2).attr('selected','selected');
-        $('#id_post_mail option').eq(1).attr('selected','selected');
-        $('#id_post_photos option').eq(0).attr('selected','selected');
-        $('#id_tag_deliver option').eq(1).attr('selected','selected');
-        $('#id_chat option').eq(1).attr('selected','selected');
-        $('#id_write_storage option').eq(0).attr('selected','selected');
-        $('#id_write_pages option').eq(0).attr('selected','selected');
-        $('#id_delegate option').eq(0).attr('selected','selected');
+	if(n == 2) {
+		$('#id_view_stream option').eq(7).attr('selected','selected');
+		$('#id_view_profile option').eq(7).attr('selected','selected');
+		$('#id_view_photos option').eq(7).attr('selected','selected');
+		$('#id_view_contacts option').eq(7).attr('selected','selected');
+		$('#id_view_storage option').eq(7).attr('selected','selected');
+		$('#id_view_pages option').eq(7).attr('selected','selected');
+		$('#id_send_stream option').eq(2).attr('selected','selected');
+		$('#id_post_wall option').eq(1).attr('selected','selected');
+		$('#id_post_comments option').eq(2).attr('selected','selected');
+		$('#id_post_mail option').eq(1).attr('selected','selected');
+		$('#id_post_photos option').eq(0).attr('selected','selected');
+		$('#id_tag_deliver option').eq(1).attr('selected','selected');
+		$('#id_chat option').eq(1).attr('selected','selected');
+		$('#id_write_storage option').eq(0).attr('selected','selected');
+		$('#id_write_pages option').eq(0).attr('selected','selected');
+		$('#id_delegate option').eq(0).attr('selected','selected');
 		$('#id_republish option').eq(1).attr('selected','selected');
 		$('#id_bookmark option').eq(1).attr('selected','selected');
 		$('#id_profile_in_directory_onoff .on').removeClass('hidden');
 		$('#id_profile_in_directory_onoff .off').addClass('hidden');
 		$('#id_profile_in_directory').val(1);
 	}
-    if(n == 3) {
-        $('#id_view_stream option').eq(6).attr('selected','selected');
-        $('#id_view_profile option').eq(6).attr('selected','selected');
-        $('#id_view_photos option').eq(6).attr('selected','selected');
-        $('#id_view_contacts option').eq(6).attr('selected','selected');
-        $('#id_view_storage option').eq(6).attr('selected','selected');
-        $('#id_view_pages option').eq(6).attr('selected','selected');
-        $('#id_send_stream option').eq(4).attr('selected','selected');
-        $('#id_post_wall option').eq(4).attr('selected','selected');
-        $('#id_post_comments option').eq(4).attr('selected','selected');
-        $('#id_post_mail option').eq(4).attr('selected','selected');
-        $('#id_post_photos option').eq(2).attr('selected','selected');
-        $('#id_tag_deliver option').eq(1).attr('selected','selected');
-        $('#id_chat option').eq(4).attr('selected','selected');
-        $('#id_write_storage option').eq(2).attr('selected','selected');
-        $('#id_write_pages option').eq(2).attr('selected','selected');
-        $('#id_delegate option').eq(0).attr('selected','selected');
-		$('#id_republish option').eq(4).attr('selected','selected');
-		$('#id_bookmark option').eq(4).attr('selected','selected');
+	if(n == 3) {
+		$('#id_view_stream option').eq(7).attr('selected','selected');
+		$('#id_view_profile option').eq(7).attr('selected','selected');
+		$('#id_view_photos option').eq(7).attr('selected','selected');
+		$('#id_view_contacts option').eq(7).attr('selected','selected');
+		$('#id_view_storage option').eq(7).attr('selected','selected');
+		$('#id_view_pages option').eq(7).attr('selected','selected');
+		$('#id_send_stream option').eq(5).attr('selected','selected');
+		$('#id_post_wall option').eq(5).attr('selected','selected');
+		$('#id_post_comments option').eq(5).attr('selected','selected');
+		$('#id_post_mail option').eq(5).attr('selected','selected');
+		$('#id_post_photos option').eq(2).attr('selected','selected');
+		$('#id_tag_deliver option').eq(1).attr('selected','selected');
+		$('#id_chat option').eq(5).attr('selected','selected');
+		$('#id_write_storage option').eq(2).attr('selected','selected');
+		$('#id_write_pages option').eq(2).attr('selected','selected');
+		$('#id_delegate option').eq(0).attr('selected','selected');
+		$('#id_republish option').eq(5).attr('selected','selected');
+		$('#id_bookmark option').eq(5).attr('selected','selected');
 		$('#id_profile_in_directory_onoff .on').removeClass('hidden');
 		$('#id_profile_in_directory_onoff .off').addClass('hidden');
 		$('#id_profile_in_directory').val(1);
 
 	}
-
-
 
 }


### PR DESCRIPTION
((Warning: I have tested this now, but not systematically every possible scenario. I now took care of the javascript and the API functions. Also I should have mentioned before that line 1332 of zot.php is changed in a way that will alter behaviour, because as I understood not excluding pending channels for perms_contacts was a bug.))

With this a user can allow some action to any user which connects
to them, even before they've connected back.

Ref.
https://mobiliza.org.br/display/478d9e71eaf55748dc646d3990651d6d34cfb7db5c38360538ec730ca3ccf908@zothub.com

Also some code cleanup and an alternative logic for handling
notifications of permission changes in zot.php.

This assumes that private posts are still restricted to people in
your addressbook. Regardless of your global permissions, a
pending channel won't get private posts, even if the post
only has a deny clause not matching the pending channel.
