### PR TITLE
Set backlink to the parent folder, not cloud's root.

### DIFF
--- a/mod/filestorage.php
+++ b/mod/filestorage.php
@@ -110,6 +110,7 @@ function filestorage_content(&$a) {
 		$channel = $a->get_channel();
 
 		$cloudpath = get_cloudpath($f) . (($f['flags'] & ATTACH_FLAG_DIR) ? '?f=&davguest=1' : '');
+		$parentpath = get_parent_cloudpath($channel['channel_id'], $channel['channel_address'], $f['hash']);
 
 		$aclselect_e = populate_acl($f,false);
 		$is_a_dir = (($f['flags'] & ATTACH_FLAG_DIR) ? true : false);
@@ -121,6 +122,7 @@ function filestorage_content(&$a) {
 			'$header' => t('Edit file permissions'),
 			'$file' => $f,
 			'$cloudpath' => z_root() . '/' . $cloudpath,
+			'$parentpath' => $parentpath,
 			'$uid' => $channel['channel_id'],
 			'$channelnick' => $channel['channel_address'],
 			'$permissions' => t('Permissions'),

--- a/view/tpl/attach_edit.tpl
+++ b/view/tpl/attach_edit.tpl
@@ -1,4 +1,4 @@
-<div id="attach-edit-backlink">< <a href="cloud/{{$channelnick}}">{{$backlink}}</a></div>
+<div id="attach-edit-backlink">< <a href="{{$parentpath}}">{{$backlink}}</a></div>
 
 <h1>{{$header}}</h1>
 


### PR DESCRIPTION
If you edit a file and click on the backlink you always returned to
the root folder of your cloud. This patch sets the correct parent
folder as backlink.
Bit messy, but looks like it works.
