### PR TITLE
Remove Remove Account link from account settings

### DIFF
--- a/mod/settings.php
+++ b/mod/settings.php
@@ -994,7 +994,9 @@ function settings_content(&$a) {
 			'$hint' => t('Please enable expert mode (in <a href="settings/features">Settings > Additional features</a>) to adjust!'),
 			'$lbl_misc' => t('Miscellaneous Settings'),
 			'$menus' => $menu,
-			'$menu_desc' => t('Personal menu to display in your channel pages'),		
+			'$menu_desc' => t('Personal menu to display in your channel pages'),
+			'$removeme' => t('Remove this channel'),
+			'$permanent' => t('Warning: This action is permanent and cannot be reversed.'),		
 		));
 
 		call_hooks('settings_form',$o);

--- a/view/tpl/settings.tpl
+++ b/view/tpl/settings.tpl
@@ -135,6 +135,8 @@
 </div>
 <div id="settings-channel-menu-end"></div>
 {{/if}}
-
+<div id="settings-remove-account-link">
+<button title="{{$permanent}}" class="btn btn-danger" type="submit" formaction="removeme">{{$removeme}}</button>
+</div>
 
 </div>

--- a/view/tpl/settings_account.tpl
+++ b/view/tpl/settings_account.tpl
@@ -2,9 +2,7 @@
 <h1>{{$title}}</h1>
 
 
-<div id="settings-remove-account-link">
-<a href="removeme" title="{{$permanent}}" >{{$removeme}}</a>
-</div>
+
 
 
 <form action="settings/account" id="settings-account-form" method="post" autocomplete="off" >


### PR DESCRIPTION
because it doesn’t remove the account. Move channel removal link to
channel page
