### PR TITLE
German documentation: Change the link to kanaele.md

### DIFF
--- a/doc/de/Home.md
+++ b/doc/de/Home.md
@@ -6,7 +6,7 @@ Dokumentation und Ressourcen zur Red-Matrix
 
 * [Grundlagen zu Red-Konten](help/Kontengrundlagen)
 * [Profile](help/Profile)
-* [Channels](help/Channels)
+* [Kanäle](help/kanaele)
 * [Connecting to Channels](help/Connecting-to-Channels)
 * [Permissions](help/Permissions)
 * [Cloud Storage](help/Cloud)


### PR DESCRIPTION
Necessary to actually enable the german help page I translated recently.
