### PR TITLE
Notifications links load on the same window(tab)

### DIFF
--- a/view/tpl/notifications_comments_item.tpl
+++ b/view/tpl/notifications_comments_item.tpl
@@ -1,3 +1,3 @@
 <div class="notif-item">
-	<a href="{{$item_link}}" target="friendica-notifications"><img src="{{$item_image}}" class="notif-image">{{$item_text}} <span class="notif-when">{{$item_when}}</span></a>
+	<a href="{{$item_link}}"><img src="{{$item_image}}" class="notif-image">{{$item_text}} <span class="notif-when">{{$item_when}}</span></a>
 </div>

--- a/view/tpl/notifications_dislikes_item.tpl
+++ b/view/tpl/notifications_dislikes_item.tpl
@@ -1,3 +1,3 @@
 <div class="notif-item">
-	<a href="{{$item_link}}" target="friendica-notifications"><img src="{{$item_image}}" class="notif-image">{{$item_text}} <span class="notif-when">{{$item_when}}</span></a>
+	<a href="{{$item_link}}"><img src="{{$item_image}}" class="notif-image">{{$item_text}} <span class="notif-when">{{$item_when}}</span></a>
 </div>

--- a/view/tpl/notifications_friends_item.tpl
+++ b/view/tpl/notifications_friends_item.tpl
@@ -1,3 +1,3 @@
 <div class="notif-item">
-	<a href="{{$item_link}}" target="friendica-notifications"><img src="{{$item_image}}" class="notif-image">{{$item_text}} <span class="notif-when">{{$item_when}}</span></a>
+	<a href="{{$item_link}}"><img src="{{$item_image}}" class="notif-image">{{$item_text}} <span class="notif-when">{{$item_when}}</span></a>
 </div>

--- a/view/tpl/notifications_likes_item.tpl
+++ b/view/tpl/notifications_likes_item.tpl
@@ -1,3 +1,3 @@
 <div class="notif-item">
-	<a href="{{$item_link}}" target="friendica-notification"><img src="{{$item_image}}" class="notif-image">{{$item_text}} <span class="notif-when">{{$item_when}}</span></a>
+	<a href="{{$item_link}}"><img src="{{$item_image}}" class="notif-image">{{$item_text}} <span class="notif-when">{{$item_when}}</span></a>
 </div>

--- a/view/tpl/notifications_posts_item.tpl
+++ b/view/tpl/notifications_posts_item.tpl
@@ -1,3 +1,3 @@
 <div class="notif-item">
-	<a href="{{$item_link}}" target="friendica-notifications"><img src="{{$item_image}}" class="notif-image">{{$item_text}} <span class="notif-when">{{$item_when}}</span></a>
+	<a href="{{$item_link}}"><img src="{{$item_image}}" class="notif-image">{{$item_text}} <span class="notif-when">{{$item_when}}</span></a>
 </div>

--- a/view/tpl/notify.tpl
+++ b/view/tpl/notify.tpl
@@ -1,3 +1,3 @@
 <div class="notif-item">
-	<a href="{{$item_link}}" target="friendica-notifications"><img src="{{$item_image}}" class="notif-image">{{$item_text}} <span class="notif-when">{{$item_when}}</span></a>
+	<a href="{{$item_link}}"><img src="{{$item_image}}" class="notif-image">{{$item_text}} <span class="notif-when">{{$item_when}}</span></a>
 </div>


### PR DESCRIPTION
Clicking on a notification was opening the link in a different window(tab). It was making navigation non intuitive, especially on mobile devices where you are not aware you actually left another open tab. Besides, all other cms or sn use a single window browsing style, afaik.
You should merge this only if you agree with this UI change :)
