### PR TITLE
Improvements to date selection

### DIFF
--- a/include/datetime.php
+++ b/include/datetime.php
@@ -140,36 +140,6 @@ function dob($dob) {
 }
 
 
-function datesel_format($f) {
-
-	$o = '';
-
-	if(strlen($f)) {
-		for($x = 0; $x < strlen($f); $x ++) {
-			switch($f[$x]) {
-				case 'y':
-					if(strlen($o))
-						$o .= '-';
-					$o .= t('year');					
-					break;
-				case 'm':
-					if(strlen($o))
-						$o .= '-';
-					$o .= t('month');					
-					break;
-				case 'd':
-					if(strlen($o))
-						$o .= '-';
-					$o .= t('day');
-					break;
-				default:
-					break;
-			}
-		}
-	}
-	return $o;
-}
-
 /**
  * returns a date selector
  * @param $format

--- a/mod/events.php
+++ b/mod/events.php
@@ -520,11 +520,6 @@ function events_content(&$a) {
 			}
 		}
 
-
-
-		$dateformat = datesel_format($f);
-		$timeformat = t('hour:minute');
-
 		require_once('include/acl_selectors.php');
 
 		$perm_defaults = array(
@@ -544,7 +539,6 @@ function events_content(&$a) {
 			'$mid' => $mid,
 	
 			'$title' => t('Event details'),
-			'$format_desc' => sprintf( t('Format is %s %s.'),$dateformat,$timeformat),
 			'$desc' => t('Starting date and Title are required.'),
 			'$catsenabled' => $catsenabled,
 			'$placeholdercategory' => t('Categories (comma-separated list)'),

--- a/mod/profiles.php
+++ b/mod/profiles.php
@@ -626,7 +626,7 @@ logger('extra_fields: ' . print_r($extra_fields,true));
 			'$lbl_fullname' => t('Your Full Name:'),
 			'$lbl_title'    => t('Title/Description:'),
 			'$lbl_gender'   => t('Your Gender:'),
-			'$lbl_bd'       => sprintf( t("Birthday \x28%s\x29:"),datesel_format($f)),
+			'$lbl_bd'       => t("Birthday :"),
 			'$lbl_address'  => t('Street Address:'),
 			'$lbl_city'     => t('Locality/City:'),
 			'$lbl_zip'      => t('Postal/Zip Code:'),


### PR DESCRIPTION
Some changes to datetimesel, so that's it possible to give minimum/maximum date instead of just year. This is currently in the form of a unix timestamp, but should perhaps be a DateTime object instead? But DateTime objects seem a bit harder to create (constuctor only takes a string?).
Also fix an issue with event finishing time being silently changed.
