### PR TITLE
Fix duplicate element id

### DIFF
--- a/view/tpl/jot.tpl
+++ b/view/tpl/jot.tpl
@@ -42,7 +42,7 @@
 					<i class="icon-camera jot-icons"></i>
 				</button>
 				<button id="wall-file-upload" class="btn btn-default btn-sm" title="{{$attach}}" >
-					<i id="wall-file-upload" class="icon-paper-clip jot-icons"></i>
+					<i id="wall-file-upload-icon" class="icon-paper-clip jot-icons"></i>
 				</button>
 				<button id="profile-link-wrapper" class="btn btn-default btn-sm" title="{{$weblink}}" ondragenter="linkdropper(event);" ondragover="linkdropper(event);" ondrop="linkdrop(event);"  onclick="jotGetLink(); return false;">
 					<i id="profile-link" class="icon-link jot-icons"></i>


### PR DESCRIPTION
Currently the duplicate id is not a problem because the correct one comes first. If the order was changed, things would break (and anyway, it's invalid HTML to have elements with the same id).
