### PR TITLE
Fix dirsearch parser to not get confused by logic terms in values and to ...

### DIFF
--- a/mod/dirsearch.php
+++ b/mod/dirsearch.php
@@ -282,35 +282,38 @@ function dir_parse_query($s) {
 
 	if($all) {
 		foreach($all as $q) {
-			if($q === 'and') {
-				$curr['logic'] = 'and';
-				continue;
-			}
-			if($q === 'or') {
-				$curr['logic'] = 'or';
-				continue;
-			}
-			if($q === 'not') {
-				$curr['logic'] .= ' not';
-				continue;
-			}
-			if(strpos($q,'=')) {
-				if(! isset($curr['logic']))
+			if($quoted_string === false) {
+				if($q === 'and') {
+					$curr['logic'] = 'and';
+					continue;
+				}
+				if($q === 'or') {
 					$curr['logic'] = 'or';
-				$curr['field'] = trim(substr($q,0,strpos($q,'=')));
-				$curr['value'] = trim(substr($q,strpos($q,'=')+1));
-				if(strpos($curr['value'],'"') !== false) {
-					$quoted_string = true;
-					$curr['value'] = substr($curr['value'],strpos($curr['value'],'"')+1);
+					continue;
 				}
-				else {
-					$ret[] = $curr;
-					$curr = array();
-					$continue;
+				if($q === 'not') {
+					$curr['logic'] .= ' not';
+					continue;
+				}
+				if(strpos($q,'=')) {
+					if(! isset($curr['logic']))
+						$curr['logic'] = 'or';
+					$curr['field'] = trim(substr($q,0,strpos($q,'=')));
+					$curr['value'] = trim(substr($q,strpos($q,'=')+1));
+					if($curr['value'][0] == '"' && $curr['value'][strlen($curr['value'])-1] != '"') {
+						$quoted_string = true;
+						$curr['value'] = substr($curr['value'],1);
+						continue;
+					}
+					else {
+						$ret[] = $curr;
+						$curr = array();
+						continue;
+					}
 				}
 			}
-			elseif($quoted_string) {
-				if(strpos($q,'"') !== false) {
+			else {
+				if($q[strlen($q)-1] == '"') {
 					$curr['value'] .= ' ' . str_replace('"','',trim($q));
 					$ret[] = $curr;
 					$curr = array();


### PR DESCRIPTION
...handle quoted single word values

This does change how queries with a quotation mark in the middle of a word is handled (only quotes at the beginning and end of words are counted), which IMHO is more sensible.
