### PR TITLE
Fix dirsearch with quoted single-word term

### DIFF
--- a/mod/dirsearch.php
+++ b/mod/dirsearch.php
@@ -305,6 +305,12 @@ function dir_parse_query($s) {
 						$curr['value'] = substr($curr['value'],1);
 						continue;
 					}
+					elseif($curr['value'][0] == '"' && $curr['value'][strlen($curr['value'])-1] == '"') {
+						$curr['value'] = substr($curr['value'],1,strlen($curr['value'])-2);
+						$ret[] = $curr;
+						$curr = array();
+						continue;
+					}	
 					else {
 						$ret[] = $curr;
 						$curr = array();


### PR DESCRIPTION
Apparently quoted single-word search terms did not quite work, because quotes were not removed from the search term. Should work now.
