### PR TITLE
Show suggestions in directory

### DIFF
--- a/include/contact_widgets.php
+++ b/include/contact_widgets.php
@@ -24,6 +24,7 @@ function findpeople_widget() {
 		'$label' => t('Connect/Follow'),
 		'$hint' => t('Examples: Robert Morgenstein, Fishing'),
 		'$findthem' => t('Find'),
+		'$suggest' => t('Channel Suggestions'),
 		'$similar' => '', // FIXME and uncomment when mod/match working // t('Similar Interests'),
 		'$random' => t('Random Profile'),
 		'$inv' => t('Invite Friends'),

--- a/mod/directory.php
+++ b/mod/directory.php
@@ -58,13 +58,14 @@ function directory_content(&$a) {
 	$keywords = (($_GET['keywords']) ? $_GET['keywords'] : '');
 
 	// Suggest channels if no search terms or keywords are given
-	$suggest = ($search == '' && $keywords == '' && local_user());
+	$suggest = (local_user() && x($_REQUEST,'suggest')) ? $_REQUEST['suggest'] : '';
 
 	if($suggest) {
 		$r = suggestion_query(local_user(),get_observer_hash());
 
 		// Remember in which order the suggestions were
 		$addresses = array();
+		$index = 0;
 		foreach($r as $rr) {
 			$addresses[$rr['xchan_addr']] = $index++;
 		}
@@ -74,12 +75,13 @@ function directory_content(&$a) {
 		foreach(array_keys($addresses) as $address) {
 			$advanced .= "address=\"$address\" ";
 		}
+		// Remove last space in the advanced query
+		$advanced = rtrim($advanced);
 
 	}
 
 	$tpl = get_markup_template('directory_header.tpl');
 
-		
 	$dirmode = intval(get_config('system','directory_mode'));
 
 	if(($dirmode == DIRECTORY_MODE_PRIMARY) || ($dirmode == DIRECTORY_MODE_STANDALONE)) {

--- a/view/tpl/peoplefind.tpl
+++ b/view/tpl/peoplefind.tpl
@@ -12,6 +12,7 @@
 	</form>
 	<ul class="nav nav-pills nav-stacked">
 		{{if $similar}}<li><a href="match" >{{$similar}}</a></li>{{/if}}
+		{{if $loggedin}}<li><a href="directory?suggest=1" >{{$suggest}}</a></li>{{/if}}
 		<li><a href="randprof" >{{$random}}</a></li>
 		{{if $loggedin}}{{if $inv}}<li><a href="invite" >{{$inv}}</a></li>{{/if}}{{/if}}
 	</ul>


### PR DESCRIPTION
Suggestions and the rest of the directory are still not combined. Instead, for now, just show either suggestions or normal directory, but using the same UI. Normal directory is the default.

Old suggestions page is still around, and the suggestion widget uses the old suggestion style.
