### PR TITLE
Don't show current channel separately in channel manager, highlight it i...

### DIFF
--- a/mod/manage.php
+++ b/mod/manage.php
@@ -46,15 +46,12 @@ function manage_content(&$a) {
 			intval(PAGE_REMOVED)
 		);
 
-		$selected_channel = null;
 		$account = get_app()->get_account();
 
 		if($r && count($r)) {
 			$channels = $r;
 			for($x = 0; $x < count($channels); $x ++) {
 				$channels[$x]['link'] = 'manage/' . intval($channels[$x]['channel_id']);
-				if($channels[$x]['channel_id'] == local_user())
-					$selected_channel = &$channels[$x]; // Needs to be a reference!
 				$channels[$x]['default'] = (($channels[$x]['channel_id'] == $account['account_default_channel']) ? "1" : ''); 
 				$channels[$x]['default_links'] = '1';
 
@@ -152,8 +149,8 @@ function manage_content(&$a) {
 	$o = replace_macros(get_markup_template('channels.tpl'), array(
 		'$header'           => t('Channel Manager'),
 		'$msg_selected'     => t('Current Channel'),
-		'$selected'         => $selected_channel,
-		'$desc'             => t('Attach to one of your channels by selecting it.'),
+		'$selected'         => local_user(),
+		'$desc'             => t('Switch to one of your channels by selecting it.'),
 		'$msg_default'      => t('Default Channel'),
 		'$msg_make_default' => t('Make Default'),
 		'$links'            => $links,

--- a/view/css/mod_manage.css
+++ b/view/css/mod_manage.css
@@ -1,7 +1,6 @@
 #channels-selected {
 	color: #666666;
 	font-size: 0.8em;
-
 }
 
 #channels-desc {
@@ -14,33 +13,23 @@
 .channels-break {
 	margin-bottom: 15px;
 }
-#selected-channel {
-	float: left;
-	margin-left: 0;
-}
-
-.channels-end.selected {
-	clear: both;
-}
-
-#selected-channel .channel-selection {
-	clear: both;
-	margin: 0 auto 0 auto;
-}
 
 .channel-selection-default {
 	font-size: 0.8em;
 	margin-bottom: 10px;
 }
 
-#all-channels .channel-selection {
+.channel-selection {
 	width: 12em;
 	height: 16em;
 	float: left;
-	margin: 0 15px 15px 0;
+	text-align: center;
 }
-.channels-end {
-	clear: both;
+
+.channel-selection img {
+	display: block;
+	margin-left: auto;
+	margin-right: auto;
 }
 
 .channel-selection-name-link {
@@ -50,7 +39,6 @@
 
 .channel-selection-name-link .channel-name {
 	padding-top: 10px;
-	text-align: left;	
 	word-wrap: break-word;
 	overflow: hidden;
 }
@@ -58,4 +46,8 @@
 .channels-notifications-wrapper {
 	clear: both;
 	padding-top: 10px;
+}
+
+.selected-channel img {
+	border: 2px solid #ff0000;
 }

--- a/view/tpl/channel.tpl
+++ b/view/tpl/channel.tpl
@@ -1,4 +1,4 @@
-<div class="channel-selection">
+<div class='channel-selection {{if $selected == $channel.channel_id}}selected-channel{{/if}}'>
 {{if $channel.default_links}}
 {{if $channel.default}}
 <div class="channel-selection-default default"><i class="icon-check"></i> {{$msg_default}}</div>
@@ -10,5 +10,3 @@
 <div class="channels-notifications-wrapper"><a href='manage/{{$channel.channel_id}}/message' style="{{if $channel.mail != 0}}color:#c60032;{{/if}}" title='{{$channel.mail|string_format:$mail_format}}'><i class="icon-envelope"></i> {{$channel.mail}}</a>&nbsp;<a href='manage/{{$channel.channel_id}}/connections/ifpending' style="{{if $channel.intros != 0}}color:#c60032;{{/if}}" title='{{$channel.intros|string_format:$intros_format}}'><i class="icon-user"></i> {{$channel.intros}}</a></div>
 <a href="{{$channel.link}}" class="channel-selection-name-link" title="{{$channel.channel_name}}"><div class="channel-name">{{$channel.channel_name}}</div></a>
 </div>
-
-<div class="channel-selection-end"></div>

--- a/view/tpl/channels.tpl
+++ b/view/tpl/channels.tpl
@@ -13,14 +13,6 @@
 {{$channel_usage_message}}
 </div>
 {{/if}}
-{{if $selected}}
-<div id="selected-channel">
-<div id="channels-selected">{{$msg_selected}}</div>
-{{include file="channel.tpl" channel=$selected}}
-</div>
-<div class="channels-end selected"></div>
-{{/if}}
-<br />
 <div id="channels-desc" class="descriptive-text">{{$desc}}</div>
 
 <div id="all-channels">


### PR DESCRIPTION
...nstead. Probably there is a more clear way to indicate the current channel than the border around the avatar, but showing the selected channel separately was a bit excessive IMHO, and took up a lot of space.
