### PR TITLE
Sort acl results according to match position (only type='c' for now)

### DIFF
--- a/mod/acl.php
+++ b/mod/acl.php
@@ -30,6 +30,9 @@ function acl_init(&$a){
 		$sql_extra = " AND `name` LIKE " . protect_sprintf( "'%" . dbesc($search) . "%'" ) . " ";
 		$sql_extra2 = "AND ( xchan_name LIKE " . protect_sprintf( "'%" . dbesc($search) . "%'" ) . " OR xchan_addr LIKE " . protect_sprintf( "'%" . dbesc($search) . "%'" ) . ") ";
 
+		// This horrible mess is needed because position also returns 0 if nothing is found. W/ould be MUCH easier if it instead returned a very large value
+		// Otherwise we could just order by LEAST(POSTION($search IN xchan_name),POSITION($search IN xchan_addr)).
+		$order_extra2 = "CASE WHEN xchan_name LIKE " . protect_sprintf( "'%" . dbesc($search) . "%'" ) ." then POSITION('".dbesc($search)."' IN xchan_name) else position('".dbesc($search)."' IN xchan_addr) end, ";
 		$col = ((strpos($search,'@') !== false) ? 'xchan_addr' : 'xchan_name' );
 		$sql_extra3 = "AND $col like " . protect_sprintf( "'%" . dbesc($search) . "%'" ) . " ";
 
@@ -141,7 +144,7 @@ function acl_init(&$a){
 	if ($type=='' || $type=='c') {
 		$r = q("SELECT abook_id as id, xchan_hash as hash, xchan_name as name, xchan_photo_s as micro, xchan_url as url, xchan_addr as nick, abook_their_perms, abook_flags 
 				FROM abook left join xchan on abook_xchan = xchan_hash 
-				WHERE abook_channel = %d AND not ( abook_flags & %d )>0 and not (xchan_flags & %d )>0 $sql_extra2 order by xchan_name asc" ,
+				WHERE abook_channel = %d AND not ( abook_flags & %d )>0 and not (xchan_flags & %d )>0 $sql_extra2 order by $order_extra2 xchan_name asc" ,
 			intval(local_user()),
 			intval(ABOOK_FLAG_BLOCKED|ABOOK_FLAG_PENDING|ABOOK_FLAG_ARCHIVED),
 			intval(XCHAN_FLAGS_DELETED)
@@ -150,7 +153,7 @@ function acl_init(&$a){
 			if((! $r) && $type == 'c') {
 				$r = q("SELECT substr(xchan_hash,1,18) as id, xchan_hash as hash, xchan_name as name, xchan_photo_s as micro, xchan_url as url, xchan_addr as nick, 0 as abook_their_perms, 0 as abook_flags 
 					FROM xchan 
-					WHERE not (xchan_flags & %d )>0 $sql_extra2 order by xchan_name asc" ,
+					WHERE not (xchan_flags & %d )>0 $sql_extra2 order by $order_extra2 xchan_name asc" ,
 					intval(XCHAN_FLAGS_DELETED)
 				);
 			}


### PR DESCRIPTION
This could be made more compact/easier to understand if someone more capable than me implemented a position-like function which returned a large value when the search string is not found (instead of 0 like regular position).