### PR TITLE
Refactor mention code to make it more reusable

### DIFF
--- a/include/items.php
+++ b/include/items.php
@@ -4715,3 +4715,34 @@ function item_remove_cid($xchan_hash,$mid,$uid) {
 		);
 	}
 }
+
+// Set item permissions based on results obtained from linkify_tags()
+function set_linkified_perms($linkified, &$str_contact_allow, &$str_group_allow, $profile_uid, $parent_item = false) {
+	$first_access_tag = true;
+	foreach($linkified as $x) {
+		$access_tag = $x['access_tag'];
+		if(($access_tag) && (! $parent_item)) {
+			logger('access_tag: ' . $tag . ' ' . print_r($access_tag,true), LOGGER_DATA);
+			if ($first_access_tag && (! get_pconfig($profile_uid,'system','no_private_mention_acl_override'))) {
+
+				// This is a tough call, hence configurable. The issue is that one can type in a @!privacy mention
+				// and also have a default ACL (perhaps from viewing a collection) and could be suprised that the 
+				// privacy mention wasn't the only recipient. So the default is to wipe out the existing ACL if a
+				// private mention is found. This can be over-ridden if you wish private mentions to be in 
+				// addition to the current ACL settings.
+
+				$str_contact_allow = '';
+				$str_group_allow = '';
+				$first_access_tag = false;
+			}
+			if(strpos($access_tag,'cid:') === 0) {
+				$str_contact_allow .= '<' . substr($access_tag,4) . '>';
+				$access_tag = '';	
+			}
+			elseif(strpos($access_tag,'gid:') === 0) {
+				$str_group_allow .= '<' . substr($access_tag,4) . '>';
+				$access_tag = '';	
+			}
+		}
+	}
+}

--- a/include/text.php
+++ b/include/text.php
@@ -2350,3 +2350,33 @@ function handle_tag($a, &$body, &$access_tag, &$str_tags, $profile_uid, $tag) {
 
 	return array('replaced' => $replaced, 'termtype' => $termtype, 'term' => $newname, 'url' => $url, 'contact' => $r[0]);
 }
+
+function linkify_tags($a, &$body, $uid, $profile_uid) {
+	$str_tags = '';
+	$tagged = array();
+	$result = array();
+
+	$tags = get_tags($body);
+	if(count($tags)) {
+		foreach($tags as $tag) {
+			// If we already tagged 'Robert Johnson', don't try and tag 'Robert'.
+			// Robert Johnson should be first in the $tags array
+
+			$fullnametagged = false;
+			for($x = 0; $x < count($tagged); $x ++) {
+				if(stristr($tagged[$x],$tag . ' ')) {
+					$fullnametagged = true;
+					break;
+				}
+			}
+			if($fullnametagged)
+				continue;
+
+			$success = handle_tag($a, $body, $access_tag, $str_tags, ($uid) ? $uid : $profile_uid , $tag); 
+			$results[] = array('success' => $success, 'access_tag' => $access_tag);
+			if($success['replaced']) $tagged[] = $tag;
+		}
+	}
+	return $results;
+}
+

--- a/view/js/mod_photos.js
+++ b/view/js/mod_photos.js
@@ -4,7 +4,7 @@ var ispublic = aStr['everybody'];
 $(document).ready(function() {
 	$(document).ready(function() { 
 		$("#photo-edit-newtag").contact_autocomplete(baseurl + '/acl', 'p', false, function(data) {
-			$("#photo-edit-newtag").val('@' + data.name.replace(' ','_')); // TODO: Get rid of underscore
+			$("#photo-edit-newtag").val('@' + data.name);
 		});
 	}); 
 


### PR DESCRIPTION
Split text replacement and permission setting into separate functions to make it easier to add tagging in other parts of the code.