### PR TITLE
Call sslify with an extra path element so files keep their names

### DIFF
--- a/include/text.php
+++ b/include/text.php
@@ -898,7 +898,8 @@ function sslify($s) {
 	$cnt = preg_match_all("/\<(.*?)src=\"(http\:.*?)\"(.*?)\>/",$s,$matches,PREG_SET_ORDER);
 	if($cnt) {
 		foreach($matches as $match) {
-			$s = str_replace($match[2],z_root() . '/sslify?f=&url=' . urlencode($match[2]),$s);
+			$filename = basename( parse_url($match[2],PHP_URL_PATH) );
+			$s = str_replace($match[2],z_root() . '/sslify/' . $filename . '?f=&url=' . urlencode($match[2]),$s);
 		}
 	}
 	return $s;


### PR DESCRIPTION
The main motivation for this is when saving images one doesn't
need to inspect and manually input the file's actual name.

There might be other benefits, perhaps in automated downloads.