### PR TITLE
make update 1133 work in PHP < 5.5

### DIFF
--- a/install/update.php
+++ b/install/update.php
@@ -1518,7 +1518,7 @@ function update_r1133() {
 			PRIMARY KEY (xp_id) )");
 		$r2 = 0;
 		foreach(array('xp_client', 'xp_channel', 'xp_perm') as $fld)
-			$r2 += (empty(q("create index $fld on xperm ($fld)")) ? 0 : 1);
+			$r2 += ((q("create index $fld on xperm ($fld)") == false) ? 0 : 1);
 			
 		$r = (($r1 && $r2) ? true : false);
 	}


### PR DESCRIPTION
empty() doesn't work on functions in PHP < 5.5. This made my hubs only spit out 500s after I pulled yesterday (hadn't pulled for over a week before).

Please review closely, I'm not sure if the solution is ok like that. (Taken from http://php.net/manual/en/function.empty.php )