### PR TITLE
Add alert to admin page about old PHP version. Fixing (un)blocking accounts in admin.

### DIFF
--- a/doc/sql_conventions.bb
+++ b/doc/sql_conventions.bb
@@ -56,7 +56,11 @@ $r = q("SELECT * FROM mail WHERE uid=%d AND $sql_extra ORDER BY created DESC LIM
 
 [b]NULL dates[/b]
 [li]To be written
-[code]Example[/code][/li]
+[code]// Example
+$r = q("DELETE FROM mail WHERE expires != '%s' AND expires < %s ",
+	dbesc(NULL_DATE),
+	db_utcnow()
+);[/code][/li]
 
 [b]Storing binary data[/b]
 [li]To be written

--- a/mod/admin.php
+++ b/mod/admin.php
@@ -1,12 +1,14 @@
 <?php
-
- /**
-  * Red admin
-  */
+/**
+ * @file mod/admin.php
+ * @brief RedMatrix's admin controller.
+ *
+ * Controller for the /admin/ area.
+ */
 
 
 /**
- * @param App $a
+ * @param App &$a
  */
 function admin_post(&$a){
 	logger('admin_post', LOGGER_DEBUG);
@@ -16,8 +18,8 @@ function admin_post(&$a){
 	}
 
 	// urls
-	if (argc() > 1){
-		switch (argv(1)){
+	if (argc() > 1) {
+		switch (argv(1)) {
 			case 'site':
 				admin_page_site_post($a);
 				break;
@@ -27,7 +29,6 @@ function admin_post(&$a){
 			case 'channels':
 				admin_page_channels_post($a);
 				break;
-
 			case 'plugins':
 				if (argc() > 2 && 
 					is_file("addon/" . argv(2) . "/" . argv(2) . ".php")){
@@ -38,7 +39,6 @@ function admin_post(&$a){
 						}
 				}
 				goaway($a->get_baseurl(true) . '/admin/plugins/' . argv(2) );
-				return; // NOTREACHED
 				break;
 			case 'themes':
 				$theme = argv(2);
@@ -51,10 +51,8 @@ function admin_post(&$a){
 				}
 				info(t('Theme settings updated.'));
 				if(is_ajax()) return;
-				
-				goaway($a->get_baseurl(true) . '/admin/themes/' . $theme );
 
-				return;
+				goaway($a->get_baseurl(true) . '/admin/themes/' . $theme );
 				break;
 			case 'logs':
 				admin_page_logs_post($a);
@@ -65,20 +63,17 @@ function admin_post(&$a){
 			case 'dbsync':
 				admin_page_dbsync_post($a);
 				break;
-
 			case 'profs':
 				admin_page_profs_post($a);
 				break;
-
 		}
 	}
 
 	goaway($a->get_baseurl(true) . '/admin' );
-	return; // NOTREACHED	
 }
 
 /**
- * @param App $a
+ * @param App $$a
  * @return string
  */
 function admin_content(&$a) {
@@ -93,29 +88,29 @@ function admin_content(&$a) {
 	 */
 
 	// array( url, name, extra css classes )
-	$aside = Array(
-		'site'	     =>	Array($a->get_baseurl(true)."/admin/site/", t("Site") , "site"),
-		'users'	     =>	Array($a->get_baseurl(true)."/admin/users/", t("Accounts") , "users"),
-		'channels'	 =>	Array($a->get_baseurl(true)."/admin/channels/", t("Channels") , "channels"),
-		'plugins'    =>	Array($a->get_baseurl(true)."/admin/plugins/", t("Plugins") , "plugins"),
-		'themes'     =>	Array($a->get_baseurl(true)."/admin/themes/", t("Themes") , "themes"),
-		'queue'      => array(z_root() . '/admin/queue', t('Inspect queue'), 'queue'),
-//		'hubloc'     =>	Array($a->get_baseurl(true)."/admin/hubloc/", t("Server") , "server"),
-		'profs'      => array(z_root() . '/admin/profs', t('Profile Config'), 'profs'),
-		'dbsync'     => Array($a->get_baseurl(true)."/admin/dbsync/", t('DB updates'), "dbsync")
+	$aside = array(
+		'site'      => array($a->get_baseurl(true)."/admin/site/", t("Site") , "site"),
+		'users'     => array($a->get_baseurl(true)."/admin/users/", t("Accounts") , "users"),
+		'channels'  => array($a->get_baseurl(true)."/admin/channels/", t("Channels") , "channels"),
+		'plugins'   => array($a->get_baseurl(true)."/admin/plugins/", t("Plugins") , "plugins"),
+		'themes'    => array($a->get_baseurl(true)."/admin/themes/", t("Themes") , "themes"),
+		'queue'     => array(z_root() . '/admin/queue', t('Inspect queue'), 'queue'),
+//		'hubloc'    => array($a->get_baseurl(true)."/admin/hubloc/", t("Server") , "server"),
+		'profs'     => array(z_root() . '/admin/profs', t('Profile Config'), 'profs'),
+		'dbsync'    => array($a->get_baseurl(true)."/admin/dbsync/", t('DB updates'), "dbsync")
 	);
-	
+
 	/* get plugins admin page */
-	
-	$r = q("SELECT * FROM `addon` WHERE `plugin_admin`=1");
-	$aside['plugins_admin']=Array();
+
+	$r = q("SELECT * FROM addon WHERE plugin_admin = 1");
+	$aside['plugins_admin'] = array();
 	foreach ($r as $h){
-		$plugin =$h['name'];
-		$aside['plugins_admin'][] = Array($a->get_baseurl(true)."/admin/plugins/".$plugin, $plugin, "plugin");
+		$plugin = $h['name'];
+		$aside['plugins_admin'][] = array($a->get_baseurl(true) . '/admin/plugins/' . $plugin, $plugin, 'plugin');
 		// temp plugins with admin
 		$a->plugins_admin[] = $plugin;
 	}
-		
+
 	$aside['logs'] = Array($a->get_baseurl(true)."/admin/logs/", t("Logs"), "logs");
 
 	$t = get_markup_template("admin_aside.tpl");
@@ -129,12 +124,11 @@ function admin_content(&$a) {
 	));
 
 
-
 	/**
 	 * Page content
 	 */
 	$o = '';
-	
+
 	// urls
 	if (argc() > 1){
 		switch (argv(1)) {
@@ -169,12 +163,12 @@ function admin_content(&$a) {
 				$o = admin_page_queue($a);
 				break;
 			default:
-				notice( t("Item not found.") );
+				notice( t('Item not found.') );
 		}
 	} else {
 		$o = admin_page_summary($a);
 	}
-	
+
 	if(is_ajax()) {
 		echo $o; 
 		killme();
@@ -182,45 +176,76 @@ function admin_content(&$a) {
 	} else {
 		return $o;
 	}
-} 
+}
 
 
 /**
- * Admin Summary Page
- * @param App $a
- * @return string
+ * @brief Returns content for Admin Summary Page.
+ *
+ * @param App $$a
+ * @return string HTML from parsed admin_summary.tpl
  */
 function admin_page_summary(&$a) {
 
-
 	// list total user accounts, expirations etc.
+	$accounts = array();
+	$r = q("SELECT COUNT(*) AS total, COUNT(IF(account_expires > %s, 1, NULL)) AS expiring, COUNT(IF(account_expires < %s AND account_expires != '%s', 1, NULL)) AS expired, COUNT(IF((account_flags & %d)>0, 1, NULL)) AS blocked FROM account",
+		db_utcnow(),
+		db_utcnow(),
+		dbesc(NULL_DATE),
+		intval(ACCOUNT_BLOCKED)
+	);
+	if ($r) {
+		$accounts['total']    = array('label' => t('# Accounts'), 'val' => $r[0]['total']);
+		//@todo $accounts['blocked'] = array('label' => t('# blocked accounts'), 'val' => $r[0]['blocked']);
+		$accounts['expired']  = array('label' => t('# expired accounts'), 'val' => $r[0]['expired']);
+		$accounts['expiring'] = array('label' => t('# expiring accounts'), 'val' => $r[0]['expiring']);
+	}
 
-
-	$r = q("SELECT COUNT(account_id) as total FROM `account`");
-	$users = $r[0]['total'];
-	
-	$r = q("SELECT COUNT(id) as `count` FROM `register`");
+	// pending registrations
+	$r = q("SELECT COUNT(id) AS `count` FROM register");
 	$pending = $r[0]['count'];
 
-	$r = q("select count(*) as total from outq where outq_delivered = 0");
-	$queue = (($r) ? $r[0]['total'] : 0);
+	// available channels, primary and clones
+	$channels = array();
+	$r = q("SELECT COUNT(*) AS total, COUNT(IF(channel_primary = 1, 1, NULL)) AS main, COUNT(IF(channel_primary = 0, 1, NULL)) AS clones FROM channel WHERE NOT (channel_pageflags & %d)>0",
+		intval(PAGE_REMOVED)
+	);
+	if ($r) {
+		$channels['total']  = array('label' => t('# Channels'), 'val' => $r[0]['total']);
+		$channels['main']   = array('label' => t('# primary'), 'val' => $r[0]['main']);
+		$channels['clones'] = array('label' => t('# clones'), 'val' => $r[0]['clones']);
+	}
 
 	// We can do better, but this is a quick queue status
-	
+	$r = q("SELECT COUNT(outq_delivered) AS total FROM outq WHERE outq_delivered = 0");
+	$queue = (($r) ? $r[0]['total'] : 0);
 	$queues = array( 'label' => t('Message queues'), 'queue' => $queue );
 
+	// If no plugins active return 0, otherwise list of plugin names
+	$plugins = (count($a->plugins) == 0) ? count($a->plugins) : $a->plugins;
 
-	$t = get_markup_template("admin_summary.tpl");
+	// Could be extended to provide also other alerts to the admin
+	$alertmsg = '';
+	// annoy admin about upcoming unsupported PHP version
+	if (version_compare(PHP_VERSION, '5.4', '<')) {
+		$alertmsg = 'Your PHP version ' . PHP_VERSION . ' will not be supported with the next major release of RedMatrix. You are strongly urged to upgrade to a current version.'
+			. '<br>PHP 5.3 has reached its <a href="http://php.net/eol.php" class="alert-link">End of Life (EOL)</a> in August 2014.'
+			. ' A list about current PHP versions can be found <a href="http://php.net/supported-versions.php" class="alert-link">here</a>.';
+	}
+
+	$t = get_markup_template('admin_summary.tpl');
 	return replace_macros($t, array(
 		'$title' => t('Administration'),
 		'$page' => t('Summary'),
+		'$adminalertmsg' => $alertmsg,
 		'$queues' => $queues,
-		'$users' => Array( t('Registered users'), $users),
-		'$accounts' => $accounts,
-		'$pending' => Array( t('Pending registrations'), $pending),
-		'$version' => Array( t('Version'), RED_VERSION),
-		'$build' =>  get_config('system','db_version'),
-		'$plugins' => Array( t('Active plugins'), $a->plugins )
+		'$accounts' => array( t('Registered accounts'), $accounts),
+		'$pending' => array( t('Pending registrations'), $pending),
+		'$channels' => array( t('Registered channels'), $channels),
+		'$plugins' => array( t('Active plugins'), $plugins ),
+		'$version' => array( t('Version'), RED_VERSION),
+		'$build' => get_config('system', 'db_version')
 	));
 }
 
@@ -230,11 +255,11 @@ function admin_page_summary(&$a) {
  *  @param App $a
  */
 function admin_page_site_post(&$a){
-	if (!x($_POST,"page_site")){
+	if (!x($_POST, 'page_site')){
 		return;
 	}
 
-    check_form_security_token_redirectOnErr('/admin/site', 'admin_site');
+	check_form_security_token_redirectOnErr('/admin/site', 'admin_site');
 
 	$sitename 			=	((x($_POST,'sitename'))			? notags(trim($_POST['sitename']))			: '');
 	$banner				=	((x($_POST,'banner'))      		? trim($_POST['banner'])				: false);
@@ -244,69 +269,66 @@ function admin_page_site_post(&$a){
 	$theme_mobile			=	((x($_POST,'theme_mobile'))		? notags(trim($_POST['theme_mobile']))			: '');
 //	$site_channel			=	((x($_POST,'site_channel'))	? notags(trim($_POST['site_channel']))				: '');
 	$maximagesize		=	((x($_POST,'maximagesize'))		? intval(trim($_POST['maximagesize']))				:  0);
-	
-	
+
 	$register_policy	=	((x($_POST,'register_policy'))	? intval(trim($_POST['register_policy']))	:  0);
 	$access_policy	=	((x($_POST,'access_policy'))	? intval(trim($_POST['access_policy']))	:  0);
 	$abandon_days	    =	((x($_POST,'abandon_days'))	    ? intval(trim($_POST['abandon_days']))	    :  0);
 
-	$register_text		=	((x($_POST,'register_text'))	? notags(trim($_POST['register_text']))		: '');	
-	
+	$register_text		=	((x($_POST,'register_text'))	? notags(trim($_POST['register_text']))		: '');
+
 	$allowed_sites		=	((x($_POST,'allowed_sites'))	? notags(trim($_POST['allowed_sites']))		: '');
 	$allowed_email		=	((x($_POST,'allowed_email'))	? notags(trim($_POST['allowed_email']))		: '');
-	$not_allowed_email		=	((x($_POST,'not_allowed_email'))	? notags(trim($_POST['not_allowed_email']))		: '');	
+	$not_allowed_email		=	((x($_POST,'not_allowed_email'))	? notags(trim($_POST['not_allowed_email']))		: '');
 	$block_public		=	((x($_POST,'block_public'))		? True	:	False);
 	$force_publish		=	((x($_POST,'publish_all'))		? True	:	False);
 	$disable_discover_tab		=	((x($_POST,'disable_discover_tab'))		? True	:	False);
 	$no_login_on_homepage	=	((x($_POST,'no_login_on_homepage'))		? True	:	False);
-	$global_directory	=	((x($_POST,'directory_submit_url'))	? notags(trim($_POST['directory_submit_url']))	: '');
-	$no_community_page	=	!((x($_POST,'no_community_page'))	? True	:	False);
+	$global_directory	= ((x($_POST,'directory_submit_url'))	? notags(trim($_POST['directory_submit_url']))	: '');
+	$no_community_page	= !((x($_POST,'no_community_page'))	? True	:	False);
 
-	$verifyssl			=	((x($_POST,'verifyssl'))		? True	:	False);
-	$proxyuser			=	((x($_POST,'proxyuser'))		? notags(trim($_POST['proxyuser']))	: '');
-	$proxy				=	((x($_POST,'proxy'))			? notags(trim($_POST['proxy']))	: '');
-	$timeout			=	((x($_POST,'timeout'))			? intval(trim($_POST['timeout']))		: 60);
-	$delivery_interval	=	((x($_POST,'delivery_interval'))? intval(trim($_POST['delivery_interval']))		: 0);
-	$poll_interval	=	((x($_POST,'poll_interval'))? intval(trim($_POST['poll_interval']))		: 0);
-	$maxloadavg	=	((x($_POST,'maxloadavg'))? intval(trim($_POST['maxloadavg']))		: 50);
-	$feed_contacts = ((x($_POST,'feed_contacts')) ? intval($_POST['feed_contacts']) : 0);
-	$diaspora_enabled = ((x($_POST,'diaspora_enabled')) ? intval($_POST['diaspora_enabled']) : 0);
-	$verify_email      =    ((x($_POST,'verify_email'))     ? 1 : 0);
+	$verifyssl         = ((x($_POST,'verifyssl'))        ? True : False);
+	$proxyuser         = ((x($_POST,'proxyuser'))        ? notags(trim($_POST['proxyuser']))  : '');
+	$proxy             = ((x($_POST,'proxy'))            ? notags(trim($_POST['proxy']))      : '');
+	$timeout           = ((x($_POST,'timeout'))          ? intval(trim($_POST['timeout']))    : 60);
+	$delivery_interval = ((x($_POST,'delivery_interval'))? intval(trim($_POST['delivery_interval'])) : 0);
+	$poll_interval     = ((x($_POST,'poll_interval'))    ? intval(trim($_POST['poll_interval'])) : 0);
+	$maxloadavg        = ((x($_POST,'maxloadavg'))       ? intval(trim($_POST['maxloadavg'])) : 50);
+	$feed_contacts     = ((x($_POST,'feed_contacts'))    ? intval($_POST['feed_contacts'])    : 0);
+	$diaspora_enabled  = ((x($_POST,'diaspora_enabled')) ? intval($_POST['diaspora_enabled']) : 0);
+	$verify_email      = ((x($_POST,'verify_email'))     ? 1 : 0);
 
-	set_config('system','feed_contacts',$feed_contacts);
-	set_config('system','diaspora_enabled',$diaspora_enabled);
-	set_config('system','delivery_interval',$delivery_interval);
-	set_config('system','poll_interval',$poll_interval);
-	set_config('system','maxloadavg',$maxloadavg);
-	set_config('system','sitename',$sitename);
-	set_config('system','no_login_on_homepage',$no_login_on_homepage);
-	set_config('system','verify_email',$verify_email);
+	set_config('system', 'feed_contacts', $feed_contacts);
+	set_config('system', 'diaspora_enabled', $diaspora_enabled);
+	set_config('system', 'delivery_interval', $delivery_interval);
+	set_config('system', 'poll_interval', $poll_interval);
+	set_config('system', 'maxloadavg', $maxloadavg);
+	set_config('system', 'sitename', $sitename);
+	set_config('system', 'no_login_on_homepage', $no_login_on_homepage);
+	set_config('system', 'verify_email', $verify_email);
 
-	if ($banner=="") {
-		del_config('system','banner');
-	} 
-	else {
-		set_config('system','banner', $banner);
+	if ($banner == '') {
+		del_config('system', 'banner');
+	} else {
+		set_config('system', 'banner', $banner);
 	}
 
-	if ($admininfo==''){
-		del_config('system','admininfo');
-	}
-	else {
+	if ($admininfo == ''){
+		del_config('system', 'admininfo');
+	} else {
 		require_once('include/text.php');
 		linkify_tags($a, $admininfo, local_channel());
-		set_config('system','admininfo', $admininfo);
+		set_config('system', 'admininfo', $admininfo);
 	}
-	set_config('system','language', $language);
-	set_config('system','theme', $theme);
+	set_config('system', 'language', $language);
+	set_config('system', 'theme', $theme);
 	if ( $theme_mobile === '---' ) {
-		del_config('system','mobile_theme');
+		del_config('system', 'mobile_theme');
 	} else {
-		set_config('system','mobile_theme', $theme_mobile);
-        }
+		set_config('system', 'mobile_theme', $theme_mobile);
+	}
 //	set_config('system','site_channel', $site_channel);
 	set_config('system','maximagesize', $maximagesize);
-	
+
 	set_config('system','register_policy', $register_policy);
 	set_config('system','access_policy', $access_policy);
 	set_config('system','account_abandon_days', $abandon_days);
@@ -317,11 +339,10 @@ function admin_page_site_post(&$a){
 	set_config('system','block_public', $block_public);
 	set_config('system','publish_all', $force_publish);
 	set_config('system','disable_discover_tab', $disable_discover_tab);
-	if($global_directory=="") {
-		del_config('system','directory_submit_url');
-	} 
-	else {
-		set_config('system','directory_submit_url', $global_directory);
+	if ($global_directory == '') {
+		del_config('system', 'directory_submit_url');
+	} else {
+		set_config('system', 'directory_submit_url', $global_directory);
 	}
 
 	set_config('system','no_community_page', $no_community_page);
@@ -333,8 +354,6 @@ function admin_page_site_post(&$a){
 
 	info( t('Site settings updated.') . EOL);
 	goaway($a->get_baseurl(true) . '/admin/site' );
-	return; // NOTREACHED	
-	
 }
 
 /**
@@ -342,11 +361,11 @@ function admin_page_site_post(&$a){
  * @return string
  */
 function admin_page_site(&$a) {
-	
+
 	/* Installed langs */
 	$lang_choices = array();
 	$langs = glob('view/*/strings.php');
-	
+
 	if(is_array($langs) && count($langs)) {
 		if(! in_array('view/en/strings.php',$langs))
 			$langs[] = 'view/en/';
@@ -358,17 +377,17 @@ function admin_page_site(&$a) {
 	}
 
 	/* Installed themes */
-    $theme_choices_mobile["---"] = t("Default");
-    $theme_choices = array();
-    $files = glob('view/theme/*');
-    if($files) {
-        foreach($files as $file) {
-		    $vars = '';
-            $f = basename($file);
-            if (file_exists($file . '/library'))
-			    continue;
-            if (file_exists($file . '/mobile'))
-			    $vars = t('mobile');
+	$theme_choices_mobile["---"] = t("Default");
+	$theme_choices = array();
+	$files = glob('view/theme/*');
+	if($files) {
+		foreach($files as $file) {
+			$vars = '';
+			$f = basename($file);
+			if (file_exists($file . '/library'))
+				continue;
+			if (file_exists($file . '/mobile'))
+				$vars = t('mobile');
 			if (file_exists($file . '/experimental'))
 				$vars .= t('experimental');
 			if (file_exists($file . '/unsupported'))
@@ -376,29 +395,30 @@ function admin_page_site(&$a) {
 			if ($vars) {
 				$theme_choices[$f] = $f . ' (' . $vars . ')';
 				$theme_choices_mobile[$f] = $f . ' (' . $vars . ')';
-            }
+			}
 			else {
-                $theme_choices[$f] = $f;
-                $theme_choices_mobile[$f] = $f;
-                }
-        }
-    }
+				$theme_choices[$f] = $f;
+				$theme_choices_mobile[$f] = $f;
+			}
+		}
+	}
 
 	/* Banner */
-	$banner = get_config('system','banner');
+	$banner = get_config('system', 'banner');
 	if($banner == false) 
 		$banner = 'red';
+
 	$banner = htmlspecialchars($banner);
-	
+
 	/* Admin Info */
-	$admininfo = get_config('system','admininfo');
+	$admininfo = get_config('system', 'admininfo');
 
 	/* Register policy */
 	$register_choices = Array(
 		REGISTER_CLOSED  => t("No"),
 		REGISTER_APPROVE => t("Yes - with approval"),
 		REGISTER_OPEN    => t("Yes")
-	); 
+	);
 
 	/* Acess policy */
 	$access_choices = Array(
@@ -407,7 +427,7 @@ function admin_page_site(&$a) {
 		ACCESS_FREE => t("My site has free access only"),
 		ACCESS_TIERED => t("My site offers free accounts with optional paid upgrades")
 	);
-	
+
 //	$ssl_choices = array(
 //		SSL_POLICY_NONE     => t("No SSL policy, links will track page SSL state"),
 //		SSL_POLICY_FULL     => t("Force all links to use SSL")
@@ -422,9 +442,9 @@ function admin_page_site(&$a) {
 		'$upload' => t('File upload'),
 		'$corporate' => t('Policies'),
 		'$advanced' => t('Advanced'),
-		
+
 		'$baseurl' => $a->get_baseurl(true),
-									// name, label, value, help string, extra data...
+		// name, label, value, help string, extra data...
 		'$sitename' 		=> array('sitename', t("Site name"), htmlspecialchars(get_config('system','sitename'), ENT_QUOTES, 'UTF-8'),''),
 		'$banner'			=> array('banner', t("Banner/Logo"), $banner, ""),
 		'$admininfo'		=> array('admininfo', t("Administrator Information"), $admininfo, t("Contact information for site administrators.  Displayed on siteinfo page.  BBCode can be used here")),
@@ -447,15 +467,14 @@ function admin_page_site(&$a) {
 		'$force_publish'	=> array('publish_all', t("Force publish"), get_config('system','publish_all'), t("Check to force all profiles on this site to be listed in the site directory.")),
 		'$disable_discover_tab'	=> array('disable_discover_tab', t("Disable discovery tab"), get_config('system','disable_discover_tab'), t("Remove the tab in the network view with public content pulled from sources chosen for this site.")),
 		'$no_login_on_homepage'	=> array('no_login_on_homepage', t("No login on Homepage"), get_config('system','no_login_on_homepage'), t("Check to hide the login form from your sites homepage when visitors arrive who are not logged in (e.g. when you put the content of the homepage in via the site channel).")),
-			
+
 		'$proxyuser'		=> array('proxyuser', t("Proxy user"), get_config('system','proxyuser'), ""),
 		'$proxy'			=> array('proxy', t("Proxy URL"), get_config('system','proxy'), ""),
 		'$timeout'			=> array('timeout', t("Network timeout"), (x(get_config('system','curl_timeout'))?get_config('system','curl_timeout'):60), t("Value is in seconds. Set to 0 for unlimited (not recommended).")),
 		'$delivery_interval'			=> array('delivery_interval', t("Delivery interval"), (x(get_config('system','delivery_interval'))?get_config('system','delivery_interval'):2), t("Delay background delivery processes by this many seconds to reduce system load. Recommend: 4-5 for shared hosts, 2-3 for virtual private servers. 0-1 for large dedicated servers.")),
 		'$poll_interval'			=> array('poll_interval', t("Poll interval"), (x(get_config('system','poll_interval'))?get_config('system','poll_interval'):2), t("Delay background polling processes by this many seconds to reduce system load. If 0, use delivery interval.")),
 		'$maxloadavg'			=> array('maxloadavg', t("Maximum Load Average"), ((intval(get_config('system','maxloadavg')) > 0)?get_config('system','maxloadavg'):50), t("Maximum system load before delivery and poll processes are deferred - default 50.")),
-        '$form_security_token' => get_form_security_token("admin_site"),
-			
+		'$form_security_token' => get_form_security_token("admin_site"),
 	));
 
 }
@@ -471,10 +490,10 @@ function admin_page_hubloc_post(&$a){
 			intval($hublocid)
 		);
 		$hublocurl = $arrhublocurl[0]['hubloc_url'] . '/post';
-		
+
 		//perform ping
 		$m = zot_build_packet($a->get_channel(),'ping');
-	        $r = zot_zot($hublocurl,$m);
+		$r = zot_zot($hublocurl,$m);
 		//handle results and set the hubloc flags in db to make results visible
 		$r2 = $r['body'];
 		$r3 = $r2['success'];
@@ -484,53 +503,44 @@ function admin_page_hubloc_post(&$a){
 		} else {
 			//set HUBLOC_OFFLINE to 1 
 			logger(' success = false ', LOGGER_DEBUG);
-
 		}
-		
+
 		//unfotunatly zping wont work, I guess return format is not correct
-		 //require_once('mod/zping.php');
-		 //$r = zping_content($hublocurl);
-        	 //logger('zping answer: ' . $r, LOGGER_DEBUG);
-		
+		//require_once('mod/zping.php');
+		//$r = zping_content($hublocurl);
+		//logger('zping answer: ' . $r, LOGGER_DEBUG);
 
 		//in case of repair store new pub key for tested hubloc (all channel with this hubloc) in db
 		//after repair set hubloc flags to 0
-
 	}
 
-
 	goaway($a->get_baseurl(true) . '/admin/hubloc' );
-	return;
 }
 
 function admin_page_hubloc(&$a) {
-	$o = '';
 	$hubloc = q("SELECT hubloc_id, hubloc_addr, hubloc_host, hubloc_status  FROM hubloc");
 
-	
 	if(! $hubloc){
 		notice( t('No server found') . EOL);
 		goaway($a->get_baseurl(true) . '/admin/hubloc');
 	}
 
-	$t = get_markup_template("admin_hubloc.tpl");
-        return replace_macros($t, array(
+	$t = get_markup_template('admin_hubloc.tpl');
+	return replace_macros($t, array(
 		'$hubloc' => $hubloc,
 		'$th_hubloc' => array(t('ID'), t('for channel'), t('on server'), t('Status')),
-                '$title' => t('Administration'),
-                '$page' => t('Server'),
-                '$queues' => $queues,
-                //'$accounts' => $accounts, /*$accounts is empty here*/
-                '$pending' => Array( t('Pending registrations'), $pending),
-                '$plugins' => Array( t('Active plugins'), $a->plugins ),
-		'$form_security_token' => get_form_security_token("admin_hubloc")
-        ));
-	return $o;
+		'$title' => t('Administration'),
+		'$page' => t('Server'),
+		'$queues' => $queues,
+		//'$accounts' => $accounts, /*$accounts is empty here*/
+		'$pending' => array( t('Pending registrations'), $pending),
+		'$plugins' => array( t('Active plugins'), $a->plugins ),
+		'$form_security_token' => get_form_security_token('admin_hubloc')
+	));
 }
 
 
 function admin_page_dbsync(&$a) {
-
 	$o = '';
 
 	if(argc() > 3 && intval(argv(3)) && argv(2) === 'mark') {
@@ -558,6 +568,7 @@ function admin_page_dbsync(&$a) {
 		}
 		else
 			$o .= sprintf( t('Update function %s could not be found.'), $func);
+
 		return $o;
 	}
 
@@ -581,10 +592,9 @@ function admin_page_dbsync(&$a) {
 		'$mark' => t('Mark success (if update was manually applied)'),
 		'$apply' => t('Attempt to execute this update step automatically'),
 		'$failed' => $failed
-	));	
+	));
 
 	return $o;
-
 }
 
 function admin_page_queue($a) {
@@ -602,7 +612,6 @@ function admin_page_queue($a) {
 			dbesc($_REQUEST['emptyhub'])
 		);
 	}
-
 
 
 	$r = q("select count(outq_posturl) as total, outq_posturl from outq 
@@ -627,7 +636,6 @@ function admin_page_queue($a) {
 	));
 
 	return $o;
-
 }
 
 /**
@@ -639,7 +647,7 @@ function admin_page_users_post(&$a){
 	$pending = ( x($_POST, 'pending') ? $_POST['pending'] : Array() );
 	$users = ( x($_POST, 'user') ? $_POST['user'] : Array() );
 
-    check_form_security_token_redirectOnErr('/admin/users', 'admin_users');
+	check_form_security_token_redirectOnErr('/admin/users', 'admin_users');
 
 	if (x($_POST,'page_users_block')){
 		foreach($users as $uid){
@@ -657,7 +665,7 @@ function admin_page_users_post(&$a){
 		}
 		notice( sprintf( tt("%s user deleted", "%s users deleted", count($users)), count($users)) );
 	}
-	
+
 	if (x($_POST,'page_users_approve')){
 		foreach($pending as $hash){
 			user_allow($hash);
@@ -669,7 +677,6 @@ function admin_page_users_post(&$a){
 		}
 	}
 	goaway($a->get_baseurl(true) . '/admin/users' );
-	return; // NOTREACHED	
 }
 
 /**
@@ -679,18 +686,18 @@ function admin_page_users_post(&$a){
 function admin_page_users(&$a){
 	if (argc() > 2) {
 		$uid = argv(3);
-		$account = q("SELECT * FROM account WHERE account_id = %d", 
+		$account = q("SELECT * FROM account WHERE account_id = %d",
 			intval($uid)
 		);
 
 		if (! $account) {
 			notice( t('Account not found') . EOL);
 			goaway($a->get_baseurl(true) . '/admin/users' );
-		}		
+		}
 
 		switch(argv(2)){
 			case "delete":{
-                check_form_security_token_redirectOnErr('/admin/users', 'admin_users', 't');
+				check_form_security_token_redirectOnErr('/admin/users', 'admin_users', 't');
 				// delete user
 				require_once("include/Contact.php");
 				account_remove($uid,true,false);
@@ -698,7 +705,7 @@ function admin_page_users(&$a){
 				notice( sprintf(t("User '%s' deleted"), $account[0]['account_email']) . EOL);
 			}; break;
 			case "block":{
-                check_form_security_token_redirectOnErr('/admin/users', 'admin_users', 't');
+				check_form_security_token_redirectOnErr('/admin/users', 'admin_users', 't');
 				q("UPDATE account SET account_flags = ( account_flags & ~%d ) where account_id = %d",
 					intval(ACCOUNT_BLOCKED),
 					intval( $uid )
@@ -708,15 +715,13 @@ function admin_page_users(&$a){
 			}; break;
 		}
 		goaway($a->get_baseurl(true) . '/admin/users' );
-		return ''; // NOTREACHED
-		
 	}
-	
+
 	/* get pending */
 	$pending = q("SELECT account.*, register.hash from account left join register on account_id = register.uid where (account_flags & %d )>0 ",
 		intval(ACCOUNT_PENDING)
-	);	
-	
+	);
+
 	/* get users */
 
 	$total = q("SELECT count(*) as total FROM account");
@@ -724,7 +729,7 @@ function admin_page_users(&$a){
 		$a->set_pager_total($total[0]['total']);
 		$a->set_pager_itemspage(100);
 	}
-	
+
 
 //	WEe'll still need to link email addresses to admin/users/channels or some such, but this bit doesn't exist yet.
 //	That's where we need to be doing last post/channel flags/etc, not here.
@@ -736,20 +741,20 @@ function admin_page_users(&$a){
 	$order = " order by account_email asc ";
 	if($_REQUEST['order'] === 'expires')
 		$order = " order by account_expires desc ";
-    if($_REQUEST['order'] === 'created')
+	if($_REQUEST['order'] === 'created')
 		$order = " order by account_created desc ";
-		
-	$users =q("SELECT `account_id` , `account_email`, `account_lastlog`, `account_created`, `account_expires`, " . 			"`account_service_class`, ( account_flags & %d )>0 as `blocked`, " .
+
+	$users = q("SELECT `account_id` , `account_email`, `account_lastlog`, `account_created`, `account_expires`, " . 			"`account_service_class`, ( account_flags & %d )>0 as `blocked`, " .
 			"(SELECT %s FROM channel as ch " .
 			"WHERE ch.channel_account_id = ac.account_id and not (ch.channel_pageflags & %d )>0) as `channels` " .
 		"FROM account as ac where true $serviceclass $order limit %d offset %d ",
 		intval(ACCOUNT_BLOCKED),
 		db_concat('ch.channel_address', ' '),
-		intval(PAGE_REMOVED),		
+		intval(PAGE_REMOVED),
 		intval($a->pager['itemspage']),
 		intval($a->pager['start'])
 	);
-					
+
 //	function _setup_users($e){
 //		$accounts = Array(
 //			t('Normal Account'), 
@@ -765,8 +770,8 @@ function admin_page_users(&$a){
 //		return $e;
 //	}
 //	$users = array_map("_setup_users", $users);
-	
-	
+
+
 	$t = get_markup_template("admin_users.tpl");
 	$o = replace_macros($t, array(
 		// strings //
@@ -789,7 +794,7 @@ function admin_page_users(&$a){
 		'$confirm_delete_multi' => t('Selected users will be deleted!\n\nEverything these users had posted on this site will be permanently deleted!\n\nAre you sure?'),
 		'$confirm_delete' => t('The user {0} will be deleted!\n\nEverything this user has posted on this site will be permanently deleted!\n\nAre you sure?'),
 
-        '$form_security_token' => get_form_security_token("admin_users"),
+		'$form_security_token' => get_form_security_token("admin_users"),
 
 		// values //
 		'$baseurl' => $a->get_baseurl(true),
@@ -798,6 +803,7 @@ function admin_page_users(&$a){
 		'$users' => $users,
 	));
 	$o .= paginate($a);
+
 	return $o;
 }
 
@@ -817,7 +823,7 @@ function admin_page_channels_post(&$a){
 			q("UPDATE channel SET channel_pageflags = ( channel_pageflags & ~%d ) where channel_id = %d",
 				intval(PAGE_CENSORED),
 				intval( $uid )
-				);
+			);
 			proc_run('php','include/directory.php',$uid,'nopush');
 		}
 		notice( sprintf( tt("%s channel censored/uncensored", "%s channels censored/uncensored", count($channels)), count($channels)) );
@@ -831,7 +837,6 @@ function admin_page_channels_post(&$a){
 	}
 
 	goaway($a->get_baseurl(true) . '/admin/channels' );
-	return; // NOTREACHED	
 }
 
 /**
@@ -841,18 +846,18 @@ function admin_page_channels_post(&$a){
 function admin_page_channels(&$a){
 	if (argc() > 2) {
 		$uid = argv(3);
-		$channel = q("SELECT * FROM channel WHERE channel_id = %d", 
+		$channel = q("SELECT * FROM channel WHERE channel_id = %d",
 			intval($uid)
 		);
 
 		if (! $channel) {
 			notice( t('Channel not found') . EOL);
 			goaway($a->get_baseurl(true) . '/admin/channels' );
-		}		
+		}
 
-		switch(argv(2)){
+		switch(argv(2)) {
 			case "delete":{
-  				check_form_security_token_redirectOnErr('/admin/channels', 'admin_channels', 't');
+				check_form_security_token_redirectOnErr('/admin/channels', 'admin_channels', 't');
 				// delete channel
 				require_once("include/Contact.php");
 				channel_remove($uid,true);
@@ -872,10 +877,8 @@ function admin_page_channels(&$a){
 			}; break;
 		}
 		goaway($a->get_baseurl(true) . '/admin/channels' );
-		return ''; // NOTREACHED
-		
 	}
-	
+
 	/* get channels */
 
 	$total = q("SELECT count(*) as total FROM channel where not (channel_pageflags & %d)>0",
@@ -885,7 +888,7 @@ function admin_page_channels(&$a){
 		$a->set_pager_total($total[0]['total']);
 		$a->set_pager_itemspage(100);
 	}
-	
+
 	$order = " order by channel_name asc ";
 
 	$channels = q("SELECT * from channel where not ( channel_pageflags & %d )>0 $order limit %d offset %d ",
@@ -893,7 +896,7 @@ function admin_page_channels(&$a){
 		intval($a->pager['itemspage']),
 		intval($a->pager['start'])
 	);
-					
+
 	if($channels) {
 		for($x = 0; $x < count($channels); $x ++) {
 			if($channels[$x]['channel_pageflags'] & PAGE_CENSORED)
@@ -902,7 +905,7 @@ function admin_page_channels(&$a){
 				$channels[$x]['blocked'] = false;
 		}
 	}
-	
+
 	$t = get_markup_template("admin_channels.tpl");
 	$o = replace_macros($t, array(
 		// strings //
@@ -920,13 +923,14 @@ function admin_page_channels(&$a){
 		'$confirm_delete_multi' => t('Selected channels will be deleted!\n\nEverything that was posted in these channels on this site will be permanently deleted!\n\nAre you sure?'),
 		'$confirm_delete' => t('The channel {0} will be deleted!\n\nEverything that was posted in this channel on this site will be permanently deleted!\n\nAre you sure?'),
 
-        '$form_security_token' => get_form_security_token("admin_channels"),
+		'$form_security_token' => get_form_security_token("admin_channels"),
 
 		// values //
 		'$baseurl' => $a->get_baseurl(true),
 		'$channels' => $channels,
 	));
 	$o .= paginate($a);
+
 	return $o;
 }
 
@@ -938,7 +942,7 @@ function admin_page_channels(&$a){
  * @return string
  */
 function admin_page_plugins(&$a){
-	
+
 	/**
 	 * Single plugin
 	 */
@@ -948,9 +952,9 @@ function admin_page_plugins(&$a){
 			notice( t("Item not found.") );
 			return '';
 		}
-		
+
 		if (x($_GET,"a") && $_GET['a']=="t"){
-            check_form_security_token_redirectOnErr('/admin/plugins', 'admin_themes', 't');
+			check_form_security_token_redirectOnErr('/admin/plugins', 'admin_plugins', 't');
 
 			// Toggle plugin status
 			$idx = array_search($plugin, $a->plugins);
@@ -965,27 +969,27 @@ function admin_page_plugins(&$a){
 			}
 			set_config("system","addon", implode(", ",$a->plugins));
 			goaway($a->get_baseurl(true) . '/admin/plugins' );
-			return ''; // NOTREACHED
 		}
 		// display plugin details
 		require_once('library/markdown.php');
 
 		if (in_array($plugin, $a->plugins)){
-			$status="on"; $action= t("Disable");
+			$status = 'on';
+			$action = t('Disable');
 		} else {
-			$status="off"; $action= t("Enable");
+			$status = 'off';
+			$action =  t('Enable');
 		}
-		
-		$readme=Null;
+
+		$readme = null;
 		if (is_file("addon/$plugin/README.md")){
 			$readme = file_get_contents("addon/$plugin/README.md");
 			$readme = Markdown($readme);
 		} else if (is_file("addon/$plugin/README")){
 			$readme = "<pre>". file_get_contents("addon/$plugin/README") ."</pre>";
-		} 
-		
-		$admin_form="";
+		}
 
+		$admin_form = '';
 		if (is_array($a->plugins_admin) && in_array($plugin, $a->plugins_admin)){
 			@require_once("addon/$plugin/$plugin.php");
 			if(function_exists($plugin.'_plugin_admin')) {
@@ -994,58 +998,55 @@ function admin_page_plugins(&$a){
 			}
 		}
 
-
-		$t = get_markup_template("admin_plugins_details.tpl");
+		$t = get_markup_template('admin_plugins_details.tpl');
 		return replace_macros($t, array(
 			'$title' => t('Administration'),
 			'$page' => t('Plugins'),
 			'$toggle' => t('Toggle'),
 			'$settings' => t('Settings'),
 			'$baseurl' => $a->get_baseurl(true),
-		
+
 			'$plugin' => $plugin,
 			'$status' => $status,
 			'$action' => $action,
 			'$info' => get_plugin_info($plugin),
 			'$str_author' => t('Author: '),
-			'$str_maintainer' => t('Maintainer: '),			
-		
+			'$str_maintainer' => t('Maintainer: '),
+
 			'$admin_form' => $admin_form,
 			'$function' => 'plugins',
 			'$screenshot' => '',
 			'$readme' => $readme,
 
-            '$form_security_token' => get_form_security_token("admin_themes"),
+			'$form_security_token' => get_form_security_token('admin_plugins'),
 		));
-	} 
-	 
-	 
-	
+	}
+
+
 	/**
 	 * List plugins
 	 */
-	
 	$plugins = array();
-	$files = glob("addon/*/");
+	$files = glob('addon/*/');
 	if($files) {
-		foreach($files as $file) {	
+		foreach($files as $file) {
 			if (is_dir($file)){
-				list($tmp, $id)=array_map("trim", explode("/",$file));
+				list($tmp, $id) = array_map('trim', explode('/', $file));
 				$info = get_plugin_info($id);
 				$plugins[] = array( $id, (in_array($id,  $a->plugins)?"on":"off") , $info);
 			}
 		}
 	}
-	
-	$t = get_markup_template("admin_plugins.tpl");
+
+	$t = get_markup_template('admin_plugins.tpl');
 	return replace_macros($t, array(
 		'$title' => t('Administration'),
 		'$page' => t('Plugins'),
 		'$submit' => t('Submit'),
 		'$baseurl' => $a->get_baseurl(true),
-		'$function' => 'plugins',	
+		'$function' => 'plugins',
 		'$plugins' => $plugins,
-        '$form_security_token' => get_form_security_token("admin_themes"),
+		'$form_security_token' => get_form_security_token('admin_plugins'),
 	));
 }
 
@@ -1074,7 +1075,7 @@ function toggle_theme(&$themes,$th,&$result) {
  * @param string $th
  * @return int
  */
-function theme_status($themes,$th) {
+function theme_status($themes, $th) {
 	for($x = 0; $x < count($themes); $x ++) {
 		if($themes[$x]['name'] === $th) {
 			if($themes[$x]['allowed']) {
@@ -1107,7 +1108,7 @@ function rebuild_theme_table($themes) {
 	return $o;
 }
 
-	
+
 /**
  * Themes admin page
  *
@@ -1115,9 +1116,9 @@ function rebuild_theme_table($themes) {
  * @return string
  */
 function admin_page_themes(&$a){
-	
-	$allowed_themes_str = get_config('system','allowed_themes');
-	$allowed_themes_raw = explode(',',$allowed_themes_str);
+
+	$allowed_themes_str = get_config('system', 'allowed_themes');
+	$allowed_themes_raw = explode(',', $allowed_themes_str);
 	$allowed_themes = array();
 	if(count($allowed_themes_raw))
 		foreach($allowed_themes_raw as $x)
@@ -1125,16 +1126,16 @@ function admin_page_themes(&$a){
 				$allowed_themes[] = trim($x);
 
 	$themes = array();
-    $files = glob('view/theme/*');
-    if($files) {
-        foreach($files as $file) {
-            $f = basename($file);
-            $is_experimental = intval(file_exists($file . '/.experimental'));
+	$files = glob('view/theme/*');
+	if($files) {
+		foreach($files as $file) {
+			$f = basename($file);
+			$is_experimental = intval(file_exists($file . '/.experimental'));
 			$is_supported = 1-(intval(file_exists($file . '/.unsupported'))); // Is not used yet
 			$is_allowed = intval(in_array($f,$allowed_themes));
 			$themes[] = array('name' => $f, 'experimental' => $is_experimental, 'supported' => $is_supported, 'allowed' => $is_allowed);
-        }
-    }
+		}
+	}
 
 	if(! count($themes)) {
 		notice( t('No themes found.'));
@@ -1151,22 +1152,21 @@ function admin_page_themes(&$a){
 			notice( t("Item not found.") );
 			return '';
 		}
-		
+
 		if (x($_GET,"a") && $_GET['a']=="t"){
-            check_form_security_token_redirectOnErr('/admin/themes', 'admin_themes', 't');
+			check_form_security_token_redirectOnErr('/admin/themes', 'admin_themes', 't');
 
 			// Toggle theme status
 
-			toggle_theme($themes,$theme,$result);
+			toggle_theme($themes, $theme, $result);
 			$s = rebuild_theme_table($themes);
 			if($result)
-				info( sprintf('Theme %s enabled.',$theme));
+				info( sprintf('Theme %s enabled.', $theme));
 			else
-				info( sprintf('Theme %s disabled.',$theme));
+				info( sprintf('Theme %s disabled.', $theme));
 
-			set_config('system','allowed_themes',$s);
+			set_config('system', 'allowed_themes', $s);
 			goaway($a->get_baseurl(true) . '/admin/themes' );
-			return ''; // NOTREACHED
 		}
 
 		// display theme details
@@ -1177,30 +1177,28 @@ function admin_page_themes(&$a){
 		} else {
 			$status="off"; $action= t("Enable");
 		}
-		
+
 		$readme=Null;
 		if (is_file("view/theme/$theme/README.md")){
 			$readme = file_get_contents("view/theme/$theme/README.md");
 			$readme = Markdown($readme);
 		} else if (is_file("view/theme/$theme/README")){
 			$readme = "<pre>". file_get_contents("view/theme/$theme/README") ."</pre>";
-		} 
-		
-		$admin_form="";
+		}
+
+		$admin_form = '';
 		if (is_file("view/theme/$theme/php/config.php")){
 			require_once("view/theme/$theme/php/config.php");
 			if(function_exists("theme_admin")){
 				$admin_form = theme_admin($a);
 			}
-			
 		}
-		
 
 		$screenshot = array( get_theme_screenshot($theme), t('Screenshot'));
 		if(! stristr($screenshot[0],$theme))
-			$screenshot = null;		
+			$screenshot = null;
 
-		$t = get_markup_template("admin_plugins_details.tpl");
+		$t = get_markup_template('admin_plugins_details.tpl');
 		return replace_macros($t, array(
 			'$title' => t('Administration'),
 			'$page' => t('Themes'),
@@ -1219,24 +1217,23 @@ function admin_page_themes(&$a){
 			'$screenshot' => $screenshot,
 			'$readme' => $readme,
 
-			'$form_security_token' => get_form_security_token("admin_themes"),
+			'$form_security_token' => get_form_security_token('admin_themes'),
 		));
-	} 
-	 
-	 
-	
+	}
+
+
 	/**
 	 * List themes
 	 */
-	
+
 	$xthemes = array();
 	if($themes) {
 		foreach($themes as $th) {
 			$xthemes[] = array($th['name'],(($th['allowed']) ? "on" : "off"), get_theme_info($th['name']));
 		}
 	}
-	
-	$t = get_markup_template("admin_plugins.tpl");
+
+	$t = get_markup_template('admin_plugins.tpl');
 	return replace_macros($t, array(
 		'$title' => t('Administration'),
 		'$page' => t('Themes'),
@@ -1246,7 +1243,7 @@ function admin_page_themes(&$a){
 		'$plugins' => $xthemes,
 		'$experimental' => t('[Experimental]'),
 		'$unsupported' => t('[Unsupported]'),
-        '$form_security_token' => get_form_security_token("admin_themes"),
+		'$form_security_token' => get_form_security_token('admin_themes'),
 	));
 }
 
@@ -1256,25 +1253,21 @@ function admin_page_themes(&$a){
  *
  * @param App $a
  */
- 
 function admin_page_logs_post(&$a) {
-	if (x($_POST,"page_logs")) {
-        check_form_security_token_redirectOnErr('/admin/logs', 'admin_logs');
+	if (x($_POST, 'page_logs')) {
+		check_form_security_token_redirectOnErr('/admin/logs', 'admin_logs');
 
-		$logfile 		=	((x($_POST,'logfile'))		? notags(trim($_POST['logfile']))	: '');
-		$debugging		=	((x($_POST,'debugging'))	? true								: false);
-		$loglevel 		=	((x($_POST,'loglevel'))		? intval(trim($_POST['loglevel']))	: 0);
+		$logfile   = ((x($_POST,'logfile'))   ? notags(trim($_POST['logfile'])) : '');
+		$debugging = ((x($_POST,'debugging')) ? true : false);
+		$loglevel  = ((x($_POST,'loglevel'))  ? intval(trim($_POST['loglevel'])) : 0);
 
 		set_config('system','logfile', $logfile);
 		set_config('system','debugging',  $debugging);
 		set_config('system','loglevel', $loglevel);
-
-		
 	}
 
-	info( t("Log settings updated.") );
+	info( t('Log settings updated.') );
 	goaway($a->get_baseurl(true) . '/admin/logs' );
-	return; // NOTREACHED	
 }
 
 /**
@@ -1282,7 +1275,7 @@ function admin_page_logs_post(&$a) {
  * @return string
  */
 function admin_page_logs(&$a){
-	
+
 	$log_choices = Array(
 		LOGGER_NORMAL => 'Normal',
 		LOGGER_TRACE => 'Trace',
@@ -1290,10 +1283,10 @@ function admin_page_logs(&$a){
 		LOGGER_DATA => 'Data',
 		LOGGER_ALL => 'All'
 	);
-	
-	$t = get_markup_template("admin_logs.tpl");
 
-	$f = get_config('system','logfile');
+	$t = get_markup_template('admin_logs.tpl');
+
+	$f = get_config('system', 'logfile');
 
 	$data = '';
 
@@ -1322,7 +1315,7 @@ readable.");
 			}
 			fclose($fp);
 		}
-	}			
+	}
 
 	return replace_macros($t, array(
 		'$title' => t('Administration'),
@@ -1332,13 +1325,13 @@ readable.");
 		'$data' => $data,
 		'$baseurl' => $a->get_baseurl(true),
 		'$logname' =>  get_config('system','logfile'),
-		
-									// name, label, value, help string, extra data...
-		'$debugging' 		=> array('debugging', t("Debugging"),get_config('system','debugging'), ""),
-		'$logfile'			=> array('logfile', t("Log file"), get_config('system','logfile'), t("Must be writable by web server. Relative to your Red top-level directory.")),
-		'$loglevel' 		=> array('loglevel', t("Log level"), get_config('system','loglevel'), "", $log_choices),
 
-        '$form_security_token' => get_form_security_token("admin_logs"),
+		// name, label, value, help string, extra data...
+		'$debugging' => array('debugging', t("Debugging"),get_config('system','debugging'), ""),
+		'$logfile'   => array('logfile', t("Log file"), get_config('system','logfile'), t("Must be writable by web server. Relative to your Red top-level directory.")),
+		'$loglevel'  => array('loglevel', t("Log level"), get_config('system','loglevel'), "", $log_choices),
+
+		'$form_security_token' => get_form_security_token('admin_logs'),
 	));
 }
 
@@ -1367,7 +1360,6 @@ function admin_page_profs_post(&$a) {
 	// add to chosen array basic or advanced
 
 	goaway(z_root() . '/admin/profs');
-
 }
 
 function admin_page_profs(&$a) {
@@ -1390,7 +1382,6 @@ function admin_page_profs(&$a) {
 			'$field_help' => array('field_help',t('Help text'),$_REQUEST['field_help'],t('Additional info (optional)')),
 			'$submit' => t('Save')
 		));
-
 	}
 
 	if((argc() > 2) && intval(argv(2))) {
@@ -1414,8 +1405,3 @@ function admin_page_profs(&$a) {
 	}
 
 }
-
-
-
-
-

--- a/view/tpl/admin_summary.tpl
+++ b/view/tpl/admin_summary.tpl
@@ -1,36 +1,32 @@
 <div class="generic-content-wrapper-styled" id='adminpage'>
 	<h1>{{$title}} - {{$page}}</h1>
-
+{{if $adminalertmsg}}
+	<p class="alert alert-warning" role="alert">{{$adminalertmsg}}</p>
+{{/if}}
 	<dl>
 		<dt>{{$queues.label}}</dt>
 		<dd>{{$queues.queue}}</dd>
 	</dl>
 	<dl>
+		<dt>{{$accounts.0}}</dt>
+		<dd>{{foreach from=$accounts.1 item=acc name=account}}<span title="{{$acc.label}}">{{$acc.val}}</span>{{if !$smarty.foreach.account.last}} / {{/if}}{{/foreach}}</dd>
+	</dl>
+	<dl>
 		<dt>{{$pending.0}}</dt>
 		<dd>{{$pending.1}}</dt>
 	</dl>
-
 	<dl>
-		<dt>{{$users.0}}</dt>
-		<dd>{{$users.1}}</dd>
+		<dt>{{$channels.0}}</dt>
+		<dd>{{foreach from=$channels.1 item=ch name=chan}}<span title="{{$ch.label}}">{{$ch.val}}</span>{{if !$smarty.foreach.chan.last}} / {{/if}}{{/foreach}}</dd>
 	</dl>
-	<!-- $accounts is empty
-		{{foreach $accounts as $p}}
-		<dl>
-			<dt>{{$p.0}}</dt>
-			<dd>{{if $p.1}}{{$p.1}}{{else}}0{{/if}}</dd>
-		</dl>
-	{{/foreach}} -->
 	<dl>
 		<dt>{{$plugins.0}}</dt>
 		<dd>
 		{{foreach $plugins.1 as $p}} {{$p}} {{/foreach}}
-		&nbsp;
 		</dd>
 	</dl>
 	<dl>
 		<dt>{{$version.0}}</dt>
 		<dd>{{$version.1}} - {{$build}}</dd>
 	</dl>
-
 </div>

--- a/view/tpl/admin_users.tpl
+++ b/view/tpl/admin_users.tpl
@@ -10,15 +10,15 @@
 		return false;
 	}
 </script>
-<div class = "generic-content-wrapper-styled" id='adminpage'>
+<div class="generic-content-wrapper-styled" id="adminpage">
 	<h1>{{$title}} - {{$page}}</h1>
-	
+
 	<form action="{{$baseurl}}/admin/users" method="post">
-        <input type='hidden' name='form_security_token' value='{{$form_security_token}}'>
-		
+		<input type="hidden" name="form_security_token" value="{{$form_security_token}}">
+
 		<h3>{{$h_pending}}</h3>
 		{{if $pending}}
-			<table id='pending'>
+			<table id="pending">
 				<thead>
 				<tr>
 					{{foreach $th_pending as $th}}<th>{{$th}}</th>{{/foreach}}
@@ -31,27 +31,25 @@
 				<tr>
 					<td class="created">{{$u.account_created}}</td>
 					<td class="email">{{$u.account_email}}</td>
-					<td class="checkbox"><input type="checkbox" class="pending_ckbx" id="id_pending_{{$u.hash}}" name="pending[]" value="{{$u.hash}}" /></td>
+					<td class="checkbox"><input type="checkbox" class="pending_ckbx" id="id_pending_{{$u.hash}}" name="pending[]" value="{{$u.hash}}"></td>
 					<td class="tools">
-						<a href="{{$baseurl}}/regmod/allow/{{$u.hash}}" title='{{$approve}}'><i class='icon-thumbs-up-alt admin-icons'></i></a>
-						<a href="{{$baseurl}}/regmod/deny/{{$u.hash}}" title='{{$deny}}'><i class='icon-thumbs-down-alt admin-icons'></i></a>
+						<a href="{{$baseurl}}/regmod/allow/{{$u.hash}}" title="{{$approve}}"><i class="icon-thumbs-up-alt admin-icons"></i></a>
+						<a href="{{$baseurl}}/regmod/deny/{{$u.hash}}" title="{{$deny}}"><i class="icon-thumbs-down-alt admin-icons"></i></a>
 					</td>
 				</tr>
 			{{/foreach}}
 				</tbody>
 			</table>
-			<div class='selectall'><a href='#' onclick="return selectall('pending_ckbx');">{{$select_all}}</a></div>
-			<div class="submit"><input type="submit" name="page_users_deny" value="{{$deny}}"/> <input type="submit" name="page_users_approve" value="{{$approve}}" /></div>			
+			<div class="selectall"><a href="#" onclick="return selectall('pending_ckbx');">{{$select_all}}</a></div>
+			<div class="submit"><input type="submit" name="page_users_deny" value="{{$deny}}"> <input type="submit" name="page_users_approve" value="{{$approve}}"></div>
 		{{else}}
 			<p>{{$no_pending}}</p>
 		{{/if}}
-	
-	
-		
-	
+
+
 		<h3>{{$h_users}}</h3>
 		{{if $users}}
-			<table id='users'>
+			<table id="users">
 				<thead>
 				<tr>
 					{{foreach $th_users as $th}}<th>{{$th}}</th>{{/foreach}}
@@ -62,28 +60,28 @@
 				<tbody>
 				{{foreach $users as $u}}
 					<tr>
-						<td class='account_id'>{{$u.account_id}}</td>
-						<td class='email'>{{if $u.blocked}}
+						<td class="account_id">{{$u.account_id}}</td>
+						<td class="email">{{if $u.blocked}}
 							<i>{{$u.account_email}}</i>
 						{{else}}
 							<strong>{{$u.account_email}}</strong>
 						{{/if}}</td>
-						<td class='channels'>{{$u.channels}}</td>
-						<td class='register_date'>{{$u.account_created}}</td>
-						<td class='login_date'>{{$u.account_lastlog}}</td>
-						<td class='account_expires'>{{$u.account_expires}}</td>
-						<td class='service_class'>{{$u.account_service_class}}</td>
-						<td class="checkbox"><input type="checkbox" class="users_ckbx" id="id_user_{{$u.account_id}}" name="user[]" value="{{$u.account_id}}"/></td>
+						<td class="channels">{{$u.channels}}</td>
+						<td class="register_date">{{$u.account_created}}</td>
+						<td class="login_date">{{$u.account_lastlog}}</td>
+						<td class="account_expires">{{$u.account_expires}}</td>
+						<td class="service_class">{{$u.account_service_class}}</td>
+						<td class="checkbox"><input type="checkbox" class="users_ckbx" id="id_user_{{$u.account_id}}" name="user[]" value="{{$u.account_id}}"><input type="hidden" name="blocked[]" value="{{$u.blocked}}"></td>
 						<td class="tools">
-							<a href="{{$baseurl}}/admin/users/block/{{$u.account_id}}?t={{$form_security_token}}" title='{{if ($u.blocked)}}{{$unblock}}{{else}}{{$block}}{{/if}}'><i class='icon-ban-circle admin-icons {{if ($u.blocked)}}dim{{/if}}'></i></a>
-							<a href="{{$baseurl}}/admin/users/delete/{{$u.account_id}}?t={{$form_security_token}}" title='{{$delete}}' onclick="return confirm_delete('{{$u.name}}')"><i class='icon-trash admin-icons'></i></a>
+							<a href="{{$baseurl}}/admin/users/{{if ($u.blocked)}}un{{/if}}block/{{$u.account_id}}?t={{$form_security_token}}" title='{{if ($u.blocked)}}{{$unblock}}{{else}}{{$block}}{{/if}}'><i class="icon-ban-circle admin-icons{{if ($u.blocked)}} dim{{/if}}"></i></a>
+							<a href="{{$baseurl}}/admin/users/delete/{{$u.account_id}}?t={{$form_security_token}}" title='{{$delete}}' onclick="return confirm_delete('{{$u.name}}')"><i class="icon-trash admin-icons"></i></a>
 						</td>
 					</tr>
 				{{/foreach}}
 				</tbody>
 			</table>
-			<div class='selectall'><a href='#' onclick="return selectall('users_ckbx');">{{$select_all}}</a></div>
-			<div class="submit"><input type="submit" name="page_users_block" value="{{$block}}/{{$unblock}}" /> <input type="submit" name="page_users_delete" value="{{$delete}}" onclick="return confirm_delete_multi()" /></div>						
+			<div class="selectall"><a href="#" onclick="return selectall('users_ckbx');">{{$select_all}}</a></div>
+			<div class="submit"><input type="submit" name="page_users_block" value="{{$block}}/{{$unblock}}"> <input type="submit" name="page_users_delete" value="{{$delete}}" onclick="return confirm_delete_multi()"></div>
 		{{else}}
 			NO USERS?!?
 		{{/if}}


### PR DESCRIPTION
Add an alert message to admin summary page when a PHP version < 5.4 was detected as this has reached EOL and will not be supported with the new SabreDAV library.
Tried to fix (un)blocking accounts in /admin/users. Not finished yet for multiple selections.
Some styleguide optimisation.
Add NULL_DATE example to doc/sql_conventions.bb.
Display a "0" when no plugins active in summary page.
Added some more numbers to summary admin page, expired accounts, channels. Hope I interpreted them right.
I have no PostgreSQL dev environment. Maybe someone can check before merging.