### PR TITLE
Extend Doxygen configuration a bit to display more.

### DIFF
--- a/util/Doxyfile
+++ b/util/Doxyfile
@@ -16,4 +16,5 @@ USE_MDFILE_AS_MAINPAGE = README
 REFERENCED_BY_RELATION = YES
 GENERATE_TREEVIEW = YES
 HTML_FOOTER = util/Doxygen.footer
-
+ALIASES += "license=@par License:\n"
+ALIASES += "fixme=\xrefitem fixme \"Fixme\" \"Fixme List\""


### PR DESCRIPTION
Add view of \license information in Doxygen and add an overview page for \fixme which is used in source code.
We have Bug List, Fixme List, Todo List and Deprecated List. Do we have some other tags we use that we could collect and display?

A preview can be seen here: http://dawnbreak.github.io/red/index.html